### PR TITLE
Certificate

### DIFF
--- a/certificate.cpp
+++ b/certificate.cpp
@@ -225,9 +225,11 @@ void Certificate::install(const std::string& filePath, bool isSkipUnitReload)
     else if (errCode == 0)
     {
         errCode = X509_STORE_CTX_get_error(storeCtx.get());
-        log<level::ERR>("Certificate verification failed",
-                        entry("FILE=%s", filePath.c_str()),
-                        entry("ERRCODE=%d", errCode));
+        log<level::INFO>(
+            "Error occured during X509_verify_cert call, checking for known "
+            "error",
+            entry("FILE=%s", filePath.c_str()), entry("ERRCODE=%d", errCode),
+            entry("ERROR_STR=%s", X509_verify_cert_error_string(errCode)));
     }
     else
     {

--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -236,7 +236,14 @@ void Manager::generateCSRHelper(
     {
         for (auto& usage : keyUsage)
         {
-            addEntry(x509Name, "keyUsage", usage);
+            if (isExtendedKeyUsage(usage))
+            {
+                addEntry(x509Name, "extendedKeyUsage", usage);
+            }
+            else
+            {
+                addEntry(x509Name, "keyUsage", usage);
+            }
         }
     }
     addEntry(x509Name, "O", organization);
@@ -291,6 +298,16 @@ void Manager::generateCSRHelper(
     writeCSR(csrFilePath, x509Req);
 }
 
+bool Manager::isExtendedKeyUsage(const std::string& usage)
+{
+    const static std::array<const char*, 6> usageList = {
+        "ServerAuthentication", "ClientAuthentication", "OCSPSigning",
+        "Timestamping",         "CodeSigning",          "EmailProtection"};
+    auto it = std::find_if(
+        usageList.begin(), usageList.end(),
+        [&usage](const char* s) { return (strcmp(s, usage.c_str()) == 0); });
+    return it != usageList.end();
+}
 EVP_PKEY_Ptr Manager::generateRSAKeyPair(const int64_t keyBitLength)
 {
     int ret = 0;

--- a/certs_manager.hpp
+++ b/certs_manager.hpp
@@ -196,6 +196,12 @@ class Manager : public Ifaces
     void addEntry(X509_NAME* x509Name, const char* field,
                   const std::string& bytes);
 
+    /** @brief Check if usage is extended key usage
+     *  @param[in] usage - key usage value
+     *  @return true if part of extended key usage
+     */
+    bool isExtendedKeyUsage(const std::string& usage);
+
     /** @brief Create CSR D-Bus object by reading the data in the CSR file
      *  @param[in] statis - SUCCESSS/FAILURE In CSR generation.
      */


### PR DESCRIPTION
This pull request fixes

1) Misleading error message logged during certificate validation
2) Adding extendedKeyUsage type 

Following patches are pulled
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-certificate-manager/+/24227/3
https://gerrit.openbmc-project.xyz/c/openbmc/phosphor-certificate-manager/+/24298/3