### PR TITLE
Allow only root user to access certificates

### DIFF
--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -39,6 +39,10 @@ Manager::Manager(sdbusplus::bus::bus& bus, sdeventplus::Event& event,
         {
             fs::create_directories(certParentInstallPath);
         }
+        auto permission = fs::perms::owner_read | fs::perms::owner_write |
+                          fs::perms::owner_exec;
+        fs::permissions(certParentInstallPath, permission,
+                        fs::perm_options::replace);
     }
     catch (fs::filesystem_error& e)
     {


### PR DESCRIPTION
This change is to cater allowing only root user to read/write
certificates.

Users with ReadOnly and Callback privilege will not be allowed to
access the certificate folder

At present setting 700 permission for the certificate folder.

Tested:
1) Verified ldap certificate at /etc/nslcd/certs is not accessible
to read only users.
2) Verified https certificate at /etc/ssl/certs/https is not
accessible to read only users
3) verfied authority certificate at /etc/ssl/certs/ is not accessible
to read only users.

Change-Id: I20acb1bf449f64282c6b692bd7063dcdedbd311d
Signed-off-by: Marri Devender Rao <devenrao@in.ibm.com>