### PR TITLE
Fixup config variable

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AC_PROG_MAKE_SET
 
 # Checks for library functions
 LT_INIT # Required for systemd linking
+AM_CONDITIONAL(HAVE_SYSTEMD, [test -n "$with_systemdsystemunitdir" -a "x$with_systemdsystemunitdir" != xno ])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])


### PR DESCRIPTION
This adds the AM_CONDITIONAL HAVE_SYSTEMD needed by bmc-acf/Makefile.am.
The problem was introduced by https://github.com/ibm-openbmc/phosphor-certificate-manager/pull/9/files.