### PR TITLE
acf: Handle error codes

### DIFF
--- a/bmc-acf/acf_manager.cpp
+++ b/bmc-acf/acf_manager.cpp
@@ -272,11 +272,13 @@ static CeLogin::CeLoginRc
             }
             else
             {
+                sRc = CeLogin::CeLoginRc::AcfExpired;
                 log<level::ERR>("ACF time expired");
             }
         }
         else
         {
+            sRc = CeLogin::CeLoginRc::SerialNumberMismatch;
             log<level::ERR>("Serial Number does not match");
         }
     }
@@ -542,6 +544,11 @@ std::tuple<std::vector<uint8_t>, bool, std::string> ACFCertMgr::getACFInfo(void)
                 elog<InternalFailure>();
             }
         }
+    }
+
+    if (sRc != CeLogin::CeLoginRc::Success)
+    {
+        isAcfInstalled = false;
     }
 
     return std::make_tuple(accessControlFile, isAcfInstalled, sDate);


### PR DESCRIPTION
This enhances the getACFInfo D-Bus call.  It will only have isAcfInstalled=true when the ACF is valid for authentication, including a matching system serial number.

Tested:
Tested with invalid system serial number.
Tested with expired ACF.
Tested with a bad ACF: echo hello >/etc/acf/service.acf

Tested via using SSH to upload the invalid ACF, then using the
busctl call xyz.openbmc_project.Certs.ACF.Manager /xyz/openbmc_project/certs/ACF xyz.openbmc_project.Certs.ACF GetACFInfo
and
GET /redfish/v1/AccountService/Accounts/service

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>