### PR TITLE
acf: add second backup production key

### DIFF
--- a/bmc-acf/acf_manager.cpp
+++ b/bmc-acf/acf_manager.cpp
@@ -508,7 +508,8 @@ std::tuple<std::vector<uint8_t>, bool, std::string> ACFCertMgr::getACFInfo(void)
 
     // ACF and production or development key should exist otherwise exit
     if (!((prodKeyExists || devKeyExists || prodBackupKeyExists ||
-           prodBackup2KeyExists) && isAcfInstalled))
+           prodBackup2KeyExists) &&
+          isAcfInstalled))
     {
         // Returns empty data as file is not installed
         return std::make_tuple(accessControlFile, isAcfInstalled, sDate);

--- a/bmc-acf/acf_manager.cpp
+++ b/bmc-acf/acf_manager.cpp
@@ -370,7 +370,8 @@ acf_info ACFCertMgr::installACF(std::vector<uint8_t> accessControlFile)
     }
 
     // This should never occur
-    if (!((prodKeyExists || devKeyExists || prodBackupKeyExists || prodBackup2KeyExists)))
+    if (!((prodKeyExists || devKeyExists || prodBackupKeyExists ||
+           prodBackup2KeyExists)))
     {
         log<level::ERR>("No usable keys exist. This shouldn't happen");
         elog<InternalFailure>();
@@ -503,7 +504,7 @@ std::tuple<std::vector<uint8_t>, bool, std::string> ACFCertMgr::getACFInfo(void)
     }
 
     // ACF and production or development key should exist otherwise exit
-    if (!((prodKeyExists || devKeyExists || prodBackupKeyExists) &&
+    if (!((prodKeyExists || devKeyExists || prodBackupKeyExists ) &&
           isAcfInstalled))
     {
         // Returns empty data as file is not installed

--- a/bmc-acf/acf_manager.cpp
+++ b/bmc-acf/acf_manager.cpp
@@ -370,9 +370,9 @@ acf_info ACFCertMgr::installACF(std::vector<uint8_t> accessControlFile)
     }
 
     // This should never occur
-    if (!((prodKeyExists || devKeyExists || prodBackupKeyExists)))
+    if (!((prodKeyExists || devKeyExists || prodBackupKeyExists || prodBackup2KeyExists)))
     {
-        log<level::ERR>("Neither prod or dev key exist. This shouldn't happen");
+        log<level::ERR>("No usable keys exist. This shouldn't happen");
         elog<InternalFailure>();
     }
 
@@ -392,7 +392,7 @@ acf_info ACFCertMgr::installACF(std::vector<uint8_t> accessControlFile)
             elog<InternalFailure>();
         }
     }
-    if (prodBackupKeyExists && sRc != CeLogin::CeLoginRc::Success)
+    if (prodBackupKeyExists && (sRc != CeLogin::CeLoginRc::Success))
     {
         std::vector<uint8_t> sPublicKeyFile;
         if (readBinaryFile(PROD_BACKUP_PUB_KEY_FILE_PATH, sPublicKeyFile))
@@ -406,7 +406,7 @@ acf_info ACFCertMgr::installACF(std::vector<uint8_t> accessControlFile)
             elog<InternalFailure>();
         }
     }
-    if (prodBackup2KeyExists && sRc != CeLogin::CeLoginRc::Success)
+    if (prodBackup2KeyExists && (sRc != CeLogin::CeLoginRc::Success))
     {
         std::vector<uint8_t> sPublicKeyFile;
         if (readBinaryFile(PROD_BACKUP2_PUB_KEY_FILE_PATH, sPublicKeyFile))


### PR DESCRIPTION
This enhances the ACF service to use the second backup production key when checking new ACFs.

Tested:
Uploading ACFs still works.
Did not test with an ACF created with the second backup production key.

Signed-off-by: Joseph Reynolds <joseph-reynolds@charter.net>