### PR TITLE
jsmn: utilize local file if available

### DIFF
--- a/bmc-acf/meson.build
+++ b/bmc-acf/meson.build
@@ -1,6 +1,10 @@
 cxx = meson.get_compiler('cpp')
 celogin_dep =  cxx.find_library('celogin')
-jsmn_dep = dependency('jsmn')
+if cxx.has_header('jsmn.h')
+    jsmn_dep = declare_dependency()
+else
+    jsmn_dep = dependency('jsmn')
+endif
 openssl_dep = dependency('openssl')
 
 bmc_acf_deps = [


### PR DESCRIPTION
Within bitbake env, we want to use the installed jsmn.h if it's available.

Downstream only code, I verified I could build this within bitbake using a new jsmn.bb recipe to pull the header into the bitbake (and avoid having meson try to auto pull the repo down).

Signed-off-by: Andrew Geissler <geissonator@yahoo.com>