### PR TITLE
Add subjectAltName extensions support

### DIFF
--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -547,7 +547,7 @@ void Manager::generateCSRHelper(
     int ret = 0;
 
     // set version of x509 req
-    int nVersion = 1;
+    int nVersion = 3;
     // TODO: Issue#6 need to make version number configurable
     X509ReqPtr x509Req(X509_REQ_new(), ::X509_REQ_free);
     ret = X509_REQ_set_version(x509Req.get(), nVersion);
@@ -560,13 +560,6 @@ void Manager::generateCSRHelper(
     // set subject of x509 req
     X509_NAME* x509Name = X509_REQ_get_subject_name(x509Req.get());
 
-    if (!alternativeNames.empty())
-    {
-        for (auto& name : alternativeNames)
-        {
-            addEntry(x509Name, "subjectAltName", name);
-        }
-    }
     addEntry(x509Name, "challengePassword", challengePassword);
     addEntry(x509Name, "L", city);
     addEntry(x509Name, "CN", commonName);
@@ -614,6 +607,35 @@ void Manager::generateCSRHelper(
             Argument::ARGUMENT_NAME("KEYPAIRALGORITHM"),
             Argument::ARGUMENT_VALUE(keyPairAlgorithm.c_str()));
     }
+
+    // set subjectAltName extension
+    X509_EXTENSION  *ext = nullptr;
+    STACK_OF (X509_EXTENSION) * extlist = nullptr;
+    extlist = sk_X509_EXTENSION_new_null ();
+
+    std::string altNameStr{};
+    if (!alternativeNames.empty())
+    {
+        for (auto& name : alternativeNames)
+        {
+            altNameStr = altNameStr + std::format("DNS:{} ", name.data());
+        }
+    }
+
+    ext = X509V3_EXT_conf_nid(NULL, NULL, NID_subject_alt_name, altNameStr.data());
+    if(ext == nullptr)
+    {
+        log<level::ERR>("Error creating subjectAltName extension");
+        elog<InternalFailure>();
+    }
+
+    sk_X509_EXTENSION_push (extlist, ext);
+    if (!X509_REQ_add_extensions (x509Req.get(), extlist))
+    {
+        log<level::ERR>("Error adding subjectAltName extension to the request");
+        elog<InternalFailure>();
+    }
+    sk_X509_EXTENSION_pop_free (extlist, X509_EXTENSION_free);
 
     ret = X509_REQ_set_pubkey(x509Req.get(), pKey.get());
     if (ret == 0)


### PR DESCRIPTION
This commit adds support to add subjectAltName extensions to CSR 

X509v3 Subject Alternative Name extension gets added to CSR

Tested by:
Generate CSR with given subject alternative names
noticed below added extension into CSR string
Requested Extensions:
X509v3 Subject Alternative Name:
DNS:cacrypt-cert-mgt DNS:carcrypt-cert-mgt.in.com