### PR TITLE
1030:Add subjectAltName extensions support

### DIFF
--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -1,6 +1,7 @@
 #include "certs_manager.hpp"
 
 #include <openssl/pem.h>
+#include <openssl/x509v3.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -23,6 +24,17 @@ using BIGNUM_Ptr = std::unique_ptr<BIGNUM, decltype(&::BN_free)>;
 using InvalidArgument =
     sdbusplus::xyz::openbmc_project::Common::Error::InvalidArgument;
 using Argument = xyz::openbmc_project::Common::InvalidArgument;
+
+struct StackX509ExtensionDeleter
+{
+    void operator()(STACK_OF(X509_EXTENSION) * ptr)
+    {
+        sk_X509_EXTENSION_pop_free(ptr, X509_EXTENSION_free);
+    }
+};
+using X509ExtListPtr =
+    std::unique_ptr<STACK_OF(X509_EXTENSION),
+                    phosphor::certs::StackX509ExtensionDeleter>;
 
 constexpr auto SUPPORTED_KEYBITLENGTH = 2048;
 
@@ -343,7 +355,7 @@ void Manager::generateCSRHelper(
     int ret = 0;
 
     // set version of x509 req
-    int nVersion = 1;
+    int nVersion = 3;
     // TODO: Issue#6 need to make version number configurable
     X509_REQ_Ptr x509Req(X509_REQ_new(), ::X509_REQ_free);
     ret = X509_REQ_set_version(x509Req.get(), nVersion);
@@ -356,13 +368,6 @@ void Manager::generateCSRHelper(
     // set subject of x509 req
     X509_NAME* x509Name = X509_REQ_get_subject_name(x509Req.get());
 
-    if (!alternativeNames.empty())
-    {
-        for (auto& name : alternativeNames)
-        {
-            addEntry(x509Name, "subjectAltName", name);
-        }
-    }
     addEntry(x509Name, "challengePassword", challengePassword);
     addEntry(x509Name, "L", city);
     addEntry(x509Name, "CN", commonName);
@@ -409,6 +414,33 @@ void Manager::generateCSRHelper(
         elog<InvalidArgument>(
             Argument::ARGUMENT_NAME("KEYPAIRALGORITHM"),
             Argument::ARGUMENT_VALUE(keyPairAlgorithm.c_str()));
+    }
+
+    // set subjectAltName extension
+    if (!alternativeNames.empty())
+    {
+        std::string altNameStr{};
+        for (auto& name : alternativeNames)
+        {
+            std::ostringstream stream;
+            stream << "DNS:" << name.data() << " ";
+            altNameStr += stream.str();
+        }
+        X509_EXTENSION* ext = X509V3_EXT_conf_nid(
+            NULL, NULL, NID_subject_alt_name, altNameStr.data());
+        if (ext == nullptr)
+        {
+            log<level::ERR>("Error creating subjectAltName extension");
+            elog<InternalFailure>();
+        }
+        X509ExtListPtr extlist(sk_X509_EXTENSION_new_null());
+        sk_X509_EXTENSION_push(extlist.get(), ext);
+        if (!X509_REQ_add_extensions(x509Req.get(), extlist.get()))
+        {
+            log<level::ERR>(
+                "Error adding subjectAltName extension to the request");
+            elog<InternalFailure>();
+        }
     }
 
     ret = X509_REQ_set_pubkey(x509Req.get(), pKey.get());


### PR DESCRIPTION
This commit adds subjectAltName extensions to CSR and avoid populating subjectAltName under subject section.

Tested by:
Generate CSR with given subject alternative names
noticed below added extension into CSR string
"Requested Extensions:
X509v3 Subject Alternative Name:
DNS:cacrypt-cert-mgt DNS:carcrypt-cert-mgt.in.com"