### PR TITLE
Modify CSR certificate version to 1

### DIFF
--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -560,7 +560,7 @@ void Manager::generateCSRHelper(
     int ret = 0;
 
     // set version of x509 req
-    int nVersion = 3;
+    int nVersion = 1;
     // TODO: Issue#6 need to make version number configurable
     X509ReqPtr x509Req(X509_REQ_new(), ::X509_REQ_free);
     ret = X509_REQ_set_version(x509Req.get(), nVersion);


### PR DESCRIPTION
This commit modifies CSR x509 certificate version back to 1.

There were issue noticed with populating x509 certificate version 3