### PR TITLE
GenerateCSR: Avoid setting CSR version

### DIFF
--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -28,8 +28,8 @@
 #include <fstream>
 #include <phosphor-logging/elog-errors.hpp>
 #include <phosphor-logging/elog.hpp>
-#include <phosphor-logging/log.hpp>
 #include <phosphor-logging/lg2.hpp>
+#include <phosphor-logging/log.hpp>
 #include <sdbusplus/bus.hpp>
 #include <sdbusplus/exception.hpp>
 #include <sdbusplus/message.hpp>
@@ -559,16 +559,7 @@ void Manager::generateCSRHelper(
 {
     int ret = 0;
 
-    // set version of x509 req
-    int nVersion = 3;
-    // TODO: Issue#6 need to make version number configurable
     X509ReqPtr x509Req(X509_REQ_new(), ::X509_REQ_free);
-    ret = X509_REQ_set_version(x509Req.get(), nVersion);
-    if (ret == 0)
-    {
-        log<level::ERR>("Error occurred during X509_REQ_set_version call");
-        elog<InternalFailure>();
-    }
 
     // set subject of x509 req
     X509_NAME* x509Name = X509_REQ_get_subject_name(x509Req.get());


### PR DESCRIPTION
Latest openssl displays as unknown version while parsing BMC generated CSRs over openssl command line

As per openssl discussion in this issue, by default CSR version set to 1 https://github.com/openssl/openssl/issues/20663
The only defined CSR version is X509_REQ_VERSION_1, so there is no need to call X509_REQ_set_version() to set version explicitly

This commit avoids calling X509_REQ_set_version() to set CSR version

Tested By:
1.Generate CSR using redfish interface
2.Parse csr using openssl and check version
  openssl req -in csr.txt -noout -text
  Certificate Request:
  Data:
    Version: 1 (0x0)

Change-Id: I29dfc50e661d39fe7930d65079abfee924745d21