### PR TITLE
Fix subjectAltName format

### DIFF
--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -615,13 +615,17 @@ void Manager::generateCSRHelper(
     // set subjectAltName extension
     if (!alternativeNames.empty())
     {
-        std::string altNameStr{};
-        for (auto& name : alternativeNames)
+        std::ostringstream oss;
+        for (size_t i = 0; i < alternativeNames.size(); ++i)
         {
-            altNameStr += std::format("DNS:{} ", name.data());
+            oss << "DNS:" << alternativeNames[i];
+            if (i < alternativeNames.size() - 1)
+            {
+                oss << ","; // Add a comma except after the last element
+            }
         }
         X509_EXTENSION* ext = X509V3_EXT_conf_nid(
-            NULL, NULL, NID_subject_alt_name, altNameStr.data());
+            NULL, NULL, NID_subject_alt_name, (oss.str()).c_str());
         if (ext == nullptr)
         {
             lg2::error("Error creating subjectAltName extension");


### PR DESCRIPTION
There is CSR format issue when multiple subject alternate names configured This commit fixes this format issue while adding multiple SAN entries.

Tesed by:
Verified by generating CSR with multiple SAN entries.
CSR output with Subject Alternative Name extension
 Attributes:
            Requested Extensions:
                X509v3 Subject Alternative Name: 
                    DNS:cacrypt.audi, DNS:cacrypt.audi.vwg, DNS:cacrypt.vwg