### PR TITLE
GenerateCSR: Avoid setting CSR version

### DIFF
--- a/bmc-acf/acf_manager.hpp
+++ b/bmc-acf/acf_manager.hpp
@@ -38,9 +38,8 @@ class ACFCertMgr : public CreateIface
      */
     ACFCertMgr(sdbusplus::bus::bus& bus, sdeventplus::Event& event,
                const char* path) :
-        CreateIface(bus, path),
-        bus(bus), event(event), objectPath(path), lastEntryId(0){};
-
+        CreateIface(bus, path), bus(bus), event(event), objectPath(path),
+        lastEntryId(0) {};
     /** @brief Implementation for InstallACF
      *  Replace the existing ACF with another ACF
      *

--- a/bmc-vmi-ca/ca_certs_manager.hpp
+++ b/bmc-vmi-ca/ca_certs_manager.hpp
@@ -39,7 +39,7 @@ class CACertMgr : public internal::ManagerInterface
      */
     CACertMgr(sdbusplus::bus_t& bus, const char* path) :
         internal::ManagerInterface(bus, path), bus(bus), objectPath(path),
-        lastEntryId(0){};
+        lastEntryId(0) {};
 
     /** @brief This method provides signing authority functionality.
                It signs the certificate and creates the CSR request entry Dbus

--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -558,16 +558,7 @@ void Manager::generateCSRHelper(
 {
     int ret = 0;
 
-    // set version of x509 req
-    int nVersion = 1;
     X509ReqPtr x509Req(X509_REQ_new(), ::X509_REQ_free);
-    ret = X509_REQ_set_version(x509Req.get(), nVersion);
-    if (ret == 0)
-    {
-        lg2::error("Error occurred during X509_REQ_set_version call");
-        ERR_print_errors_fp(stderr);
-        elog<InternalFailure>();
-    }
 
     // set subject of x509 req
     X509_NAME* x509Name = X509_REQ_get_subject_name(x509Req.get());

--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -143,9 +143,9 @@ std::vector<std::string> splitCertificates(const std::string& sourceFilePath)
 Manager::Manager(sdbusplus::bus_t& bus, sdeventplus::Event& event,
                  const char* path, CertificateType type,
                  const std::string& unit, const std::string& installPath) :
-    internal::ManagerInterface(bus, path),
-    bus(bus), event(event), objectPath(path), certType(type),
-    unitToRestart(std::move(unit)), certInstallPath(std::move(installPath)),
+    internal::ManagerInterface(bus, path), bus(bus), event(event),
+    objectPath(path), certType(type), unitToRestart(std::move(unit)),
+    certInstallPath(std::move(installPath)),
     certParentInstallPath(fs::path(certInstallPath).parent_path())
 {
     try

--- a/test/certs_manager_test.cpp
+++ b/test/certs_manager_test.cpp
@@ -214,9 +214,7 @@ class MainApp
 {
   public:
     MainApp(phosphor::certs::Manager* manager,
-            phosphor::certs::CSR* csr = nullptr) :
-        manager(manager),
-        csr_(csr)
+            phosphor::certs::CSR* csr = nullptr) : manager(manager), csr_(csr)
     {}
     void install(std::string& path)
     {


### PR DESCRIPTION
Latest openssl displays as unknown version while parsing BMC generated CSRs over openssl command line

As per openssl discussion in this issue, by default CSR version set to 1 https://github.com/openssl/openssl/issues/20663
The only defined CSR version is X509_REQ_VERSION_1, so there is no need to call X509_REQ_set_version() to set version explicitly

This commit avoids calling X509_REQ_set_version() to set CSR version

Tested By:
1.Generate CSR using redfish interface
2.Parse csr using openssl and check version
  openssl req -in csr.txt -noout -text
  Certificate Request:
  Data:
    Version: 1 (0x0)

Change-Id: I29dfc50e661d39fe7930d65079abfee924745d21