### PR TITLE
Adding the correct EKU

### DIFF
--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -678,7 +678,7 @@ void Manager::generateCSRHelper(
 bool Manager::isExtendedKeyUsage(const std::string& usage)
 {
     const static std::array<const char*, 6> usageList = {
-        "ServerAuthentication", "ClientAuthentication", "OCSPSigning",
+        "serverAuth", "clientAuth", "OCSPSigning",
         "Timestamping",         "CodeSigning",          "EmailProtection"};
     auto it = std::find_if(
         usageList.begin(), usageList.end(),


### PR DESCRIPTION
This commit adds proper EKU  extensions for server and client certficate subjectAltName.

Tested by:
Verified by generating the CSR and confirmed it has proper EKU strings.

Change-Id: I8ec41bbc89331e2b6c264180a6ccd7c5aca250ea