### PR TITLE
Added methods for IBM-ACF upload functionality

### DIFF
--- a/bmc-acf/acf_manager.cpp
+++ b/bmc-acf/acf_manager.cpp
@@ -1,0 +1,135 @@
+#include <acf_manager.hpp>
+#include <phosphor-logging/elog-errors.hpp>
+#include <phosphor-logging/elog.hpp>
+#include <phosphor-logging/log.hpp>
+#include <tacf.hpp>
+#include <xyz/openbmc_project/Certs/error.hpp>
+
+#include <filesystem>
+#include <vector>
+
+namespace acf
+{
+namespace cert
+{
+using namespace phosphor::logging;
+
+using InvalidCertificate =
+    sdbusplus::xyz::openbmc_project::Certs::Error::InvalidCertificate;
+
+using Reason = xyz::openbmc_project::Certs::InvalidCertificate::REASON;
+
+constexpr auto ACF_FILE_PATH = "/etc/acf/service.acf";
+
+/** @brief Implementation for readBinaryFile
+ *  Read file contents into buffer
+ *
+ *  @param[in] fileNameParm - Path of file.
+ *  @param[out] bufferParm - Buffer to store contents of file.
+ *
+ *  @return Status of if read was successful.
+ */
+static bool readBinaryFile(const std::string fileNameParm,
+                           std::vector<uint8_t>& bufferParm)
+{
+    std::ifstream sInputFile;
+    if (fileNameParm.empty())
+    {
+        return false;
+    }
+
+    // Open the file.
+    sInputFile.open(fileNameParm.c_str(), std::ios::binary);
+    sInputFile.unsetf(std::ios::skipws);
+    if (!sInputFile)
+    {
+        return false;
+    }
+
+    // Get the size of the file.
+    std::error_code ec;
+    std::filesystem::path path = fileNameParm;
+    std::uintmax_t size = file_size(path, ec);
+    if (ec)
+    {
+        return false;
+    }
+
+    // Read the file.
+    bufferParm.reserve(size);
+    bufferParm.assign(size, 0);
+    sInputFile.read((char*)bufferParm.data(), size);
+    sInputFile.close();
+
+    return true;
+}
+
+bool acfInstalled()
+{
+    std::error_code ec;
+    std::filesystem::path path = ACF_FILE_PATH;
+    bool exists = std::filesystem::exists(path, ec);
+    if (ec)
+    {
+        return false;
+    }
+    return exists;
+}
+
+acf_info ACFCertMgr::installACF(std::vector<uint8_t> accessControlFile)
+{
+    std::string sDate;
+
+    // delete acf file if accessControlFile is empty
+    if (accessControlFile.empty() && acfInstalled())
+    {
+        std::remove(ACF_FILE_PATH);
+        return std::make_tuple(accessControlFile, acfInstalled(), sDate);
+    }
+    // Verify and install ACF and get expiration date.
+    Tacf tacf{[](std::string msg) {
+        log<phosphor::logging::level::INFO>(msg.c_str());
+    }};
+    int rc =
+        tacf.install(accessControlFile.data(), accessControlFile.size(), sDate);
+    if (rc)
+    {
+        log<level::INFO>("ACF install failed");
+        log<level::ERR>("Error: ", entry("rc=%0x", rc));
+        elog<InvalidCertificate>(Reason("ACF validation failed"));
+    }
+
+    return std::make_tuple(accessControlFile, acfInstalled(), sDate);
+}
+
+std::tuple<std::vector<uint8_t>, bool, std::string> ACFCertMgr::getACFInfo(void)
+{
+    std::string sDate;
+    std::vector<uint8_t> accessControlFile;
+
+    if (!readBinaryFile(ACF_FILE_PATH, accessControlFile))
+    {
+        log<level::ERR>("ACF not installed or not readable");
+    }
+    else
+    {
+        // Verify ACF and get expiration date.
+        Tacf tacf{[](std::string msg) {
+            log<phosphor::logging::level::INFO>(msg.c_str());
+        }};
+        int rc = tacf.verify(accessControlFile.data(), accessControlFile.size(),
+                             sDate);
+        if (rc)
+        {
+            log<level::INFO>("ACF is not valid");
+            log<level::ERR>("Error: ", entry("rc=%0x", rc));
+            accessControlFile.clear();
+            sDate.clear();
+        }
+    }
+
+    return std::make_tuple(accessControlFile, acfInstalled(), sDate);
+}
+
+} // namespace cert
+} // namespace acf

--- a/bmc-acf/acf_manager.hpp
+++ b/bmc-acf/acf_manager.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/server/object.hpp>
+#include <sdeventplus/source/event.hpp>
+#include <xyz/openbmc_project/Certs/ACF/server.hpp>
+typedef std::tuple<std::vector<uint8_t>, bool, std::string> acf_info;
+
+namespace acf
+{
+namespace cert
+{
+
+class ACFCertMgr;
+
+using CreateIface = sdbusplus::server::object::object<
+    sdbusplus::xyz::openbmc_project::Certs::server::ACF>;
+using Mgr = acf::cert::ACFCertMgr;
+
+/** @class Manager
+ *  @brief Implementation for the
+ *         xyz.openbmc_project.Certs.ACF.Manager DBus API.
+ */
+class ACFCertMgr : public CreateIface
+{
+  public:
+    ACFCertMgr() = delete;
+    ACFCertMgr(const ACFCertMgr&) = delete;
+    ACFCertMgr& operator=(const ACFCertMgr&) = delete;
+    ACFCertMgr(ACFCertMgr&&) = delete;
+    ACFCertMgr& operator=(ACFCertMgr&&) = delete;
+    virtual ~ACFCertMgr() = default;
+
+    /** @brief Constructor to put object onto bus at a dbus path.
+     *  @param[in] bus - Bus to attach to.
+     *  @param[in] path - Path to attach at.
+     *  @param[in] event - sd event handler.
+     */
+    ACFCertMgr(sdbusplus::bus::bus& bus, sdeventplus::Event& event,
+               const char* path) :
+        CreateIface(bus, path), bus(bus), event(event), objectPath(path),
+        lastEntryId(0) {};
+
+    /** @brief Implementation for InstallACF
+     *  Replace the existing ACF with another ACF
+     *
+     *  @param[in] ACFfile - ACF contents.
+     *
+     *  @return ACF related information.
+     */
+    acf_info installACF(std::vector<uint8_t>) override;
+
+    /** @brief Implementation for GetACFInfo
+     *  Returns contents of installed ACF
+     *
+     *  @return ACF related information.
+     */
+    acf_info getACFInfo(void) override;
+
+  private:
+    /** @brief sdbusplus DBus bus connection. */
+    sdbusplus::bus::bus& bus;
+    // sdevent Event handle
+    sdeventplus::Event& event;
+    /** @brief object path */
+    std::string objectPath;
+    /** @brief Id of the last certificate entry */
+    uint32_t lastEntryId;
+};
+
+} // namespace cert
+} // namespace acf

--- a/bmc-acf/mainapp.cpp
+++ b/bmc-acf/mainapp.cpp
@@ -1,0 +1,29 @@
+#include "config.h"
+
+#include "acf_manager.hpp"
+
+#include <sdeventplus/event.hpp>
+
+#include <string>
+
+int main(int /*argc*/, char** /*argv*/)
+{
+    auto bus = sdbusplus::bus::new_default();
+    static constexpr auto objPath = "/xyz/openbmc_project/certs/ACF";
+
+    // Add sdbusplus ObjectManager
+    sdbusplus::server::manager::manager objManager(bus, objPath);
+
+    // Get default event loop
+    auto event = sdeventplus::Event::get_default();
+
+    // Attach the bus to sd_event to service user requests
+    bus.attach_event(event.get(), SD_EVENT_PRIORITY_NORMAL);
+
+    acf::cert::ACFCertMgr manager(bus, event, objPath);
+
+    std::string busName = "xyz.openbmc_project.Certs.ACF.Manager";
+    bus.request_name(busName.c_str());
+    event.loop();
+    return 0;
+}

--- a/bmc-acf/meson.build
+++ b/bmc-acf/meson.build
@@ -1,0 +1,42 @@
+cxx = meson.get_compiler('cpp')
+celogin_dep =  cxx.find_library('celogin')
+if cxx.has_header('jsmn.h')
+    jsmn_dep = declare_dependency()
+else
+    jsmn_dep = dependency('jsmn')
+endif
+openssl_dep = dependency('openssl')
+tacf_dep = dependency('tacf', required : true)
+
+bmc_acf_deps = [
+    celogin_dep,
+    jsmn_dep,
+    openssl_dep,
+    phosphor_dbus_interfaces_dep,
+    phosphor_logging_dep,
+    sdbusplus_dep,
+    sdeventplus_dep,
+    tacf_dep,
+]
+
+bmc_acf_lib = static_library(
+    'bmc_acf',
+    [
+        'acf_manager.cpp',
+    ],
+    include_directories: '..',
+    dependencies: bmc_acf_deps,
+)
+
+bmc_acf_dep = declare_dependency(
+    link_with: bmc_acf_lib,
+    dependencies: bmc_acf_deps,
+)
+
+executable(
+    'bmc-acf',
+    'mainapp.cpp',
+    include_directories: '..',
+    dependencies: bmc_acf_dep,
+    install: true,
+)

--- a/dist/bmc-acf-manager.service
+++ b/dist/bmc-acf-manager.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=BMC ACF manager
+
+[Service]
+ExecStart=/usr/bin/env bmc-acf
+SyslogIdentifier=bmc-acf
+Restart=always
+
+Type=dbus
+BusName=xyz.openbmc_project.Certs.ACF.Manager
+
+[Install]
+WantedBy=multi-user.target

--- a/dist/meson.build
+++ b/dist/meson.build
@@ -12,6 +12,10 @@ if not get_option('ca-cert-extension').disabled()
     service_files += 'bmc-vmi-ca-manager.service'
 endif
 
+if not get_option('acf-cert-extension').disabled()
+    service_files += 'bmc-acf-manager.service'
+endif
+
 if not get_option('config-bmcweb').disabled()
     busconfig += 'busconfig/phosphor-bmcweb-cert-config.conf'
     certs += 'env/bmcweb'

--- a/meson.build
+++ b/meson.build
@@ -87,6 +87,10 @@ if not get_option('ca-cert-extension').disabled()
     subdir('bmc-vmi-ca')
 endif
 
+if not get_option('acf-cert-extension').disabled()
+  subdir('bmc-acf')
+endif
+
 subdir('dist')
 
 if not get_option('tests').disabled()

--- a/meson.options
+++ b/meson.options
@@ -13,8 +13,12 @@ option(
     description: 'Enable CA certificate manager (IBM specific)',
 )
 
-option(
-    'config-bmcweb',
+option('acf-cert-extension',
+    type: 'feature',
+    description: 'Enable ACF certificate manager (IBM specific)'
+)
+
+option('config-bmcweb',
     type: 'feature',
     description: 'Install bmcweb cert configs',
 )


### PR DESCRIPTION
These methods allow the upload and info
    getting for ACF files.
    Method names respectively are installACF and getACFInfo

Supported functions were also added for validating the ACF
    on upload. Now links with ibm-acf for functionality.

installACF is meant to validate the ACF file contents passed
    as the argument.
    If valid then install file. Do not install file if invalid.
    If ACFfile contents are empty, treat as request to delete
        installed acf.
    Returns the contents of the installed ACF

getACFInfo validates installed ACF file and returns ACF
    contents (accessControlFile) and ACF info
    (isAcfInstalled == false, sDate == "")

This ACF interface is intended to be called from bmcweb.
    bmcweb receives an encoded ACF file,decodes it,
    calls this intf.method through dbus, validates
    contents, and returns info back to the request

    If getACFInfo method it isn't passed an argument
    and validates the currently install ACF file and
    returns info about the installed file

Tested:
    Test case 1
    1) Ensure ACF is not present
    2) Call getACFInfo which returns:
        (accessControlFile == {},
        isAcfInstalled == false,
        sDate == "")

    Test case 2
    1) Ensure ACF is present
    2) Call getACFInfo which returns:
        (accessControlFile == {binaryData},
        isAcfInstalled == true,
        sDate == "ACF expiration")

    Test case 3
    1) Ensure ACF is not present
    2) Call installACF with ACFFile binary contents
    3) Valid ACF passes validation:
        (Signature, serial number, expiration)
    4) File contents are written to install destination
    5) Call returns:
        (accessControlFile == {binaryData},
        isAcfInstalled == true,
        sDate == "ACF expiration")

    Test case 4
    1) Ensure ACF is not present
    2) Call installACF with ACFFile binary contents
    3) Invalid ACF fails validation:
        (Signature, serial number, expiration)
    4) ACF is not installed
    5) Call returns:
        (accessControlFile == {},
        isAcfInstalled == false,
        sDate == "")

This commit also includes squashing in follow-on ACF commits that were discovered over time:
- Add support for backup production key
- acf: add second backup production key
- acf: handle blank serial number
- acf: Handle error codes
- Add support for ACF V2 and targeted ACF. (#23)
- jsmn: utilize local file if available

Detailed notes on ACF V2 commit:

Add support for targeted ACF which leverages
ACF V2 and new targeted ACF (tacf) code that
will reside in the ibm-acf component source
code. The phosphor-certificate-manager ACF
code still primarily consists of only ACF-
install and ACF-info with the targeted ACF
support being implemented indirectly in the
tacf code. Targeted ACF currently supports
service and admin-reset types of ACF V2.
Targeted ACF support for both these types
also support V2 ACF anti-replay. Service
ACF V1 is still supported.

Change-Id: Ia81fa34e78828194f200e0025113c25c4c8afdeb