### PR TITLE
acfshell: Adding acfshell service for targeted acf

### DIFF
--- a/acfshell/README.md
+++ b/acfshell/README.md
@@ -1,0 +1,78 @@
+# Acf Shell
+
+A shell environment for running shell scripts embedded in targeted ACF files.
+This allows dynamic execution of scripts as part of the ACF workflow, enabling
+custom script running using targeted acf.
+
+## D-Bus Interfaces
+
+The service provides objects implementing the `xyz.openbmc_project.TacfShell`
+interface. To eliminate dependencies on the `phosphor-dbus-interfaces`
+repository, no YAML interface files are used. The `TacfShell` interface supports
+the following methods:
+
+```sh
+xyz.openbmc_project.TacfShell       interface -         -            -
+.active                             method    -         as           -
+.cancel                             method    s         b            -
+.start                              method    stb       b            -
+```
+
+## Design
+
+```mermaid
+---
+config:
+  layout: dagre
+---
+flowchart TD
+ subgraph s1["acf-manager"]
+    direction TB
+        D{"Validate and Extract Metadata"}
+        C["acf-manager Service"]
+        E["Return Error to bmcweb"]
+        F["Extract Metadata"]
+        G{"Identify ACF Type"}
+        H["Resource Dump Handler"]
+        I["bmcshell Handler"]
+        J["Service Handler"]
+        K["Admin Reset Handler"]
+        L["acfshell Service"]
+  end
+ subgraph acfshell["acfshell"]
+    direction TB
+        M["Shell object"]
+        subgraph async["Async Script Execution"]
+          direction TB
+            N["Script Object"]
+            O["Script Runner"]
+            P["Timer Task"]
+            Q["Finished Script"]
+            R{"Dump Needed"}
+            S["Clear Results"]
+            T["Execute Dump"]
+        end
+  end
+    A["Redfish Client"] -- Installs ACF file --> B["bmcweb"]
+    B -- Invokes --> C
+    C --> D
+    D -- Validation Failed --> E
+    D -- Validation Success --> F
+    F --> G
+    G -- Resource Dump --> H
+    G -- bmcshell --> I
+    G -- Service --> J
+    G -- Admin Reset --> K
+    I -- Invokes --> L
+    L --> M
+    M -- Creates --> N
+    N -- Assigns shell Task  --> O
+    N -- Starts Timer  --> P
+    P -- Timeout --> O
+    O --> Q
+    Q --> R
+    R -- Yes --> T
+    T -- Finished --> S
+    R -- No --> S
+
+```

--- a/acfshell/acf_shell_iface.hpp
+++ b/acfshell/acf_shell_iface.hpp
@@ -1,0 +1,266 @@
+#pragma once
+#include "script_iface.hpp"
+#include "script_runner.hpp"
+#include "sdbus_calls_runner.hpp"
+
+#include <memory>
+#include <vector>
+namespace scrrunner
+/**
+ * @struct AcfShellIface
+ * @brief Manages the D-Bus interface for ACF shell script execution.
+ *
+ * The AcfShellIface structure encapsulates the logic for exposing and managing
+ * script execution over D-Bus. It provides methods to query active scripts,
+ * start new scripts, and cancel running scripts via D-Bus method calls.
+ * The interface is registered under the bus name "xyz.openbmc_project.acfshell"
+ * and object path "/xyz/openbmc_project/acfshell" with the interface name
+ * "xyz.openbmc_project.TacfShell".
+ *
+ * Members:
+ * - io_context: Reference to the Boost.Asio IO context for asynchronous
+ * operations.
+ * - scriptRunner: Reference to the ScriptRunner responsible for executing
+ * scripts.
+ * - conn: Shared pointer to the sdbusplus ASIO connection for D-Bus
+ * communication.
+ * - dbusServer: D-Bus object server for registering interfaces and methods.
+ * - iface: Shared pointer to the D-Bus interface for the shell.
+ * - busName: D-Bus bus name for the shell interface.
+ * - objPath: D-Bus object path for the shell interface.
+ * - interface: D-Bus interface name for the shell.
+ * - scriptIfaces: Container for active ScriptIface instances.
+ *
+ * Key Methods:
+ * - AcfShellIface(...): Constructor that initializes the D-Bus interface and
+ * registers methods.
+ * - addToActive(...): Adds and starts a script, managing its lifecycle.
+ * - runScript(...): Runs a script and manages its timeout and storage.
+ * - execute(...): Asynchronously executes a script via D-Bus.
+ * - getScriptIface(...): Retrieves a ScriptIface by script ID.
+ * - removeFromActive(...): Removes a script from the active list by ID.
+ */
+{
+struct AcfShellIface
+{
+    net::io_context& io_context;
+    ScriptRunner& scriptRunner;
+    std::shared_ptr<sdbusplus::asio::connection> conn;
+    sdbusplus::asio::object_server dbusServer;
+    std::shared_ptr<sdbusplus::asio::dbus_interface> iface;
+    static constexpr std::string_view busName = "xyz.openbmc_project.acfshell";
+    static constexpr std::string_view objPath = "/xyz/openbmc_project/acfshell";
+    static constexpr std::string_view interface =
+        "xyz.openbmc_project.TacfShell";
+    std::vector<std::unique_ptr<ScriptIface>> scriptIfaces;
+    /**
+     * @brief Constructs an AcfShellIface object to manage D-Bus interface for
+     * script execution.
+     *
+     * This constructor initializes the D-Bus interface for the ACF shell,
+     * registers methods for querying active scripts, starting new scripts, and
+     * cancelling running scripts.
+     *
+     * @param ioc Reference to the Boost.Asio IO context used for asynchronous
+     * operations.
+     * @param runner Reference to the ScriptRunner responsible for executing
+     * scripts.
+     * @param conn Shared pointer to the sdbusplus ASIO connection for D-Bus
+     * communication.
+     *
+     * The following D-Bus methods are registered:
+     * - "active": Returns a list of currently active script IDs.
+     * - "start": Starts a new script with the given name, timeout, and
+     * dumpNeeded flag.
+     * - "cancel": Cancels the script with the specified ID.
+     */
+    AcfShellIface(net::io_context& ioc, ScriptRunner& runner,
+                  std::shared_ptr<sdbusplus::asio::connection> conn) :
+        io_context(ioc), scriptRunner(runner), conn(conn), dbusServer(conn)
+    {
+        iface = dbusServer.add_interface(objPath.data(), interface.data());
+        // test generic properties
+
+        iface->register_method("active", [this]() {
+            std::vector<std::string> activeScripts;
+            for (const auto& iface : scriptIfaces)
+            {
+                activeScripts.push_back(iface->data.id);
+            }
+            return activeScripts;
+        });
+
+        iface->register_method(
+            "start", [this](const std::string& script, uint64_t timeout,
+                            bool dumpNeeded) {
+                ensureMaxActiveScripts();
+                return addToActive(script, timeout, dumpNeeded);
+            });
+        iface->register_method("cancel", [this](const std::string& id) {
+            auto iface = getScriptIface(id);
+            if (iface)
+            {
+                return iface->cancel();
+            }
+            return false;
+        });
+
+        iface->initialize();
+    }
+    void ensureMaxActiveScripts()
+    {
+        // Ensure the number of active scripts does not exceed a certain limit
+        constexpr size_t maxActiveScripts = 1;
+        while (scriptIfaces.size() >= maxActiveScripts)
+        {
+            LOG_DEBUG(
+                "Cancelling oldest script to maintain max active scripts");
+            auto iface = std::move(scriptIfaces.front());
+            scriptIfaces.erase(scriptIfaces.begin());
+            iface->cancel();
+        }
+    }
+    auto makeScriptId(const std::string& script)
+    {
+        // Prepend current time to the script before hashing
+        auto now = std::chrono::system_clock::now();
+        auto now_time_t = std::chrono::system_clock::to_time_t(now);
+        std::string scriptWithTime = std::to_string(now_time_t) + "_" + script;
+        auto scriptId = ScriptRunner::makeHash(scriptWithTime);
+        return scriptId;
+    }
+    /**
+     * @brief Adds a script to the list of active scripts and starts its
+     * execution.
+     *
+     * This function generates a unique hash for the provided script, logs the
+     * attempt to start the script, and creates a new ScriptIface instance to
+     * manage the script execution. The script is then started with the
+     * specified timeout and dumpNeeded flag. If any error occurs during the
+     * process, it is logged and the function returns false.
+     *
+     * @param script The script content to be executed.
+     * @param timeout The timeout value (in seconds) for the script execution.
+     * @param dumpNeeded Indicates whether a dump is needed after script
+     * execution.
+     * @return true if the script was successfully added and started, false
+     * otherwise.
+     */
+    bool addToActive(const std::string& script, uint64_t timeout,
+                     bool dumpNeeded)
+    {
+        auto scriptId = makeScriptId(script);
+
+        LOG_DEBUG("Starting script: {}", scriptId.value());
+        if (!scriptId)
+        {
+            LOG_ERROR("Failed to create script hash");
+            return false;
+        }
+        try
+        {
+            auto iface = std::make_unique<ScriptIface>(
+                io_context, scriptRunner,
+                ScriptIface::Data{script, *scriptId, timeout, dumpNeeded},
+                dbusServer);
+            return runScript(std::move(iface));
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("Failed to create script interface: {}", e.what());
+            return false;
+        }
+    }
+    /**
+     * @brief Runs a script using the provided ScriptIface instance.
+     *
+     * This function attempts to start the script specified in the given
+     * ScriptIface object by invoking the scriptRunner. If the script starts
+     * successfully, it initiates a timeout for the script and stores the
+     * ScriptIface instance for further management. If the script fails to
+     * start, an error is logged and the function returns false.
+     *
+     * @param iface A unique pointer to a ScriptIface object containing script
+     * data.
+     * @return true if the script was started successfully, false otherwise.
+     */
+    bool runScript(std::unique_ptr<ScriptIface> iface)
+    {
+        bool success = scriptRunner.run_script(
+            iface->data.id, iface->data.script, iface->data.dumpNeeded,
+            std::bind_front(&AcfShellIface::removeFromActive, this));
+        if (!success)
+        {
+            LOG_ERROR("Failed to start script");
+            return false;
+        }
+        iface->startTimeout();
+        scriptIfaces.push_back(std::move(iface));
+        return success;
+    }
+    /**
+     * @brief Executes a script asynchronously via a D-Bus method call.
+     *
+     * This function initiates the execution of the specified script by making
+     * an asynchronous D-Bus call to the "start" method of the given interface.
+     * It uses a default timeout of 30 seconds and passes the script, timeout,
+     * and a boolean flag as arguments to the method call.
+     *
+     * @param script The script to be executed.
+     * @return net::awaitable<void> An awaitable representing the asynchronous
+     * operation.
+     *
+     * @note Logs an error message if the D-Bus method call fails.
+     */
+    net::awaitable<void> execute(const std::string& script)
+    {
+        uint64_t timeout = 30;
+        auto [ec, value] = co_await awaitable_dbus_method_call<bool>(
+            *conn, busName.data(), objPath.data(), interface.data(), "start",
+            script, timeout, true);
+
+        if (ec)
+        {
+            LOG_ERROR("Error starting script: {}", ec.message());
+        }
+    }
+    ScriptIface* getScriptIface(std::string scriptId)
+    {
+        auto it = std::find_if(scriptIfaces.begin(), scriptIfaces.end(),
+                               [scriptId](const auto& iface) {
+                                   return iface->data.id == scriptId;
+                               });
+        if (it != scriptIfaces.end())
+        {
+            return it->get();
+        }
+        return nullptr;
+    }
+    /**
+     * @brief Removes a script interface from the active list by its script ID.
+     *
+     * Searches for a script interface in the scriptIfaces container whose
+     * data.id matches the provided scriptId. If found, removes it from the
+     * container.
+     *
+     * @param unused Unused boost::system::error_code parameter.
+     * @param scriptId The ID of the script interface to remove.
+     * @return true if the script interface was found and removed; false
+     * otherwise.
+     */
+    bool removeFromActive(boost::system::error_code /*unused*/,
+                          std::string scriptId)
+    {
+        auto it = std::find_if(scriptIfaces.begin(), scriptIfaces.end(),
+                               [scriptId](const auto& iface) {
+                                   return iface->data.id == scriptId;
+                               });
+        if (it != scriptIfaces.end())
+        {
+            scriptIfaces.erase(it);
+            return true;
+        }
+        return false;
+    }
+};
+} // namespace scrrunner

--- a/acfshell/logger.hpp
+++ b/acfshell/logger.hpp
@@ -1,0 +1,100 @@
+#pragma once
+#include <systemd/sd-journal.h>
+
+#include <format>
+#include <iostream>
+#include <string>
+#undef LOG_WARNING
+#undef LOG_ERROR
+#undef LOG_DEBUG
+#undef LOG_INFO
+namespace scrrunner
+{
+enum class LogLevel
+{
+    DEBUG,
+    INFO,
+    WARNING,
+    ERROR
+};
+template <typename OutputStream>
+class Logger
+{
+  public:
+    Logger(LogLevel level, OutputStream& outputStream) :
+        currentLogLevel(level), output(outputStream)
+    {}
+
+    void log(const char* filename, int lineNumber, LogLevel level,
+             const std::string& message) const
+    {
+        if (isLogLevelEnabled(level))
+        {
+            output << std::format("{}:{} ", filename, lineNumber) << message
+                   << "\n";
+            output.flush(currentLogLevel);
+        }
+    }
+
+    void setLogLevel(LogLevel level)
+    {
+        currentLogLevel = level;
+    }
+
+  private:
+    LogLevel currentLogLevel;
+    OutputStream& output;
+
+    bool isLogLevelEnabled(LogLevel level) const
+    {
+        return level >= currentLogLevel;
+    }
+};
+struct Lg2Logger
+{
+    std::string message;
+    Lg2Logger& operator<<(const std::string& data)
+    {
+        message += data;
+        return *this;
+    }
+    void flush(LogLevel level)
+    {
+        // Write to systemd journal using sd_journal_send
+        // Requires linking with -lsystemd and including <systemd/sd-journal.h>
+        sd_journal_send("MESSAGE=%s", message.c_str(), "PRIORITY=%i", level,
+                        NULL);
+        message.clear();
+    }
+};
+
+inline Logger<Lg2Logger>& getLogger()
+{
+    static Lg2Logger lg2Logger;
+    static Logger<Lg2Logger> logger(LogLevel::ERROR, lg2Logger);
+    return logger;
+}
+} // namespace scrrunner
+
+// Macros for clients to use logger
+#define LOG_DEBUG(message, ...)                                                \
+    scrrunner::getLogger().log(                                                \
+        __FILE__, __LINE__, scrrunner::LogLevel::DEBUG,                        \
+        std::format("{} :" message, "Debug", ##__VA_ARGS__))
+#define LOG_INFO(message, ...)                                                 \
+    scrrunner::getLogger().log(                                                \
+        __FILE__, __LINE__, scrrunner::LogLevel::INFO,                         \
+        std::format("{} :" message, "Info", ##__VA_ARGS__))
+#define LOG_WARNING(message, ...)                                              \
+    scrrunner::getLogger().log(                                                \
+        __FILE__, __LINE__, scrrunner::LogLevel::WARNING,                      \
+        std::format("{} :" message, "Warning", ##__VA_ARGS__))
+#define LOG_ERROR(message, ...)                                                \
+    scrrunner::getLogger().log(                                                \
+        __FILE__, __LINE__, scrrunner::LogLevel::ERROR,                        \
+        std::format("{} :" message, "Error", ##__VA_ARGS__))
+
+#define CLIENT_LOG_DEBUG(message, ...) LOG_DEBUG(message, ##__VA_ARGS__)
+#define CLIENT_LOG_INFO(message, ...) LOG_INFO(message, ##__VA_ARGS__)
+#define CLIENT_LOG_WARNING(message, ...) LOG_WARNING(message, ##__VA_ARGS__)
+#define CLIENT_LOG_ERROR(message, ...) LOG_ERROR(message, ##__VA_ARGS__)

--- a/acfshell/make_awaitable_runner.hpp
+++ b/acfshell/make_awaitable_runner.hpp
@@ -1,0 +1,95 @@
+/**
+ * @file make_awaitable_runner.hpp
+ * @brief Utilities for creating awaitable handlers and managing coroutine
+ * results with Boost.Asio.
+ *
+ * This header provides helper types and functions to simplify the creation of
+ * awaitable handlers using Boost.Asio's coroutine and awaitable features. It
+ * allows for flexible handling of asynchronous operations, including automatic
+ * error code management and tuple-based result passing.
+ *
+ * Namespace: scrrunner
+ *
+ * Functions and Types:
+ * - mut_awaitable(): Returns a mutable reference to a static use_awaitable_t
+ * instance for use in async operations.
+ * - PrependEC<Types...>: Tuple type that prepends boost::system::error_code to
+ * a list of types.
+ * - ReturnTuple<RetTypes...>: Resolves to a tuple with error_code prepended if
+ * not already present.
+ * - AwaitableResult<Types...>: Alias for net::awaitable with the appropriate
+ * ReturnTuple.
+ * - PromiseType<Handler, Types...>: Helper struct to wrap a handler and provide
+ * a setValues method for result passing.
+ * - make_awaitable_handler<Ret..., HandlerFunc>: Factory function to create an
+ * awaitable handler from a given function, automatically handling error code
+ * and result tuple construction.
+ *
+ * Usage:
+ * These utilities are intended for use in asynchronous code where results (and
+ * optionally error codes) need to be passed through coroutines in a type-safe
+ * and convenient manner.
+ */
+#pragma once
+#include <boost/asio.hpp>
+#include <boost/asio/awaitable.hpp>
+#include <boost/asio/coroutine.hpp>
+#include <boost/asio/spawn.hpp>
+#include <boost/asio/use_awaitable.hpp>
+namespace net = boost::asio;
+
+namespace scrrunner
+{
+inline net::use_awaitable_t<>& mut_awaitable()
+{
+    static net::use_awaitable_t<> myawitable;
+    return myawitable;
+}
+
+template <typename... Types>
+using PrependEC = std::tuple<boost::system::error_code, Types...>;
+template <typename... RetTypes>
+using ReturnTuple = std::conditional_t<
+    std::is_same_v<boost::system::error_code,
+                   std::tuple_element_t<0, std::tuple<RetTypes...>>>,
+    std::tuple<RetTypes...>, PrependEC<RetTypes...>>;
+
+template <typename... Types>
+using AwaitableResult = net::awaitable<ReturnTuple<Types...>>;
+template <typename Handler, typename... Types>
+struct PromiseType
+{
+    Handler promise;
+    void setValues(Types... values)
+    {
+        promise(ReturnTuple<Types...>{std::move(values)...});
+    }
+};
+
+template <typename... Ret, typename HanlderFunc>
+auto make_awaitable_handler(HanlderFunc&& h)
+{
+    return [h = std::move(h)]() -> AwaitableResult<Ret...> {
+        co_return co_await net::async_initiate<
+            net::use_awaitable_t<>, ReturnTuple<Ret...>(ReturnTuple<Ret...>)>(
+            [h = std::move(h)](auto handler) {
+                if constexpr (std::is_same_v<
+                                  boost::system::error_code,
+                                  std::tuple_element_t<0, std::tuple<Ret...>>>)
+                {
+                    PromiseType<decltype(handler), Ret...> promise{
+                        std::move(handler)};
+                    h(std::move(promise));
+                }
+                else
+                {
+                    PromiseType<decltype(handler), boost::system::error_code,
+                                Ret...>
+                        promise{std::move(handler)};
+                    h(std::move(promise));
+                }
+            },
+            mut_awaitable());
+    };
+}
+} // namespace scrrunner

--- a/acfshell/meson.build
+++ b/acfshell/meson.build
@@ -1,0 +1,19 @@
+#project('acfshell', 'cpp', version: '1.0.0', default_options: ['cpp_std=c++23','cpp_args=-Wno-subobject-linkage'])
+boost_dep = dependency('boost', modules: ['coroutine'], required: true)
+openssl_dep = dependency('openssl', required: true)
+sdbusplus_dep = dependency('sdbusplus', required: false, include_type: 'system')
+executable(
+    'acfshell',
+    'script_runner.cpp',
+    dependencies: [boost_dep, openssl_dep, sdbusplus_dep],
+    install: true,
+    install_dir: '/usr/bin',
+)
+install_data(
+    'service/xyz.openbmc_project.acfshell.service',
+    install_dir: '/etc/systemd/system',
+)
+install_data(
+    'service/xyz.openbmc_project.acfshell.conf',
+    install_dir: '/etc/dbus-1/system.d/',
+)

--- a/acfshell/script_iface.hpp
+++ b/acfshell/script_iface.hpp
@@ -1,0 +1,111 @@
+#pragma once
+#include "script_runner.hpp"
+#include "sdbus_calls_runner.hpp"
+
+#include <format>
+namespace scrrunner
+{
+/**
+ * @brief Represents a D-Bus interface for managing script execution.
+ *
+ * The struct encapsulates the running instance of a script, which can be
+ * cancelled and monitored through this interface. The instance of this
+ * interface will be removed automatically once the script execution ends
+ * normally, is cancelled, or times out.
+ *
+ * Usage:
+ * - Instantiated with references to the IO context, a ScriptRunner, script
+ * data, and an object server.
+ * - Registers a "cancel" method on the D-Bus interface to allow external
+ * cancellation.
+ * - Manages a timeout for script execution, automatically cancelling the script
+ * if the timeout elapses.
+ *
+ * Members:
+ * - Data: Holds script-specific information such as the script content, ID,
+ * timeout, and whether a dump is needed.
+ * - scriptPath: Format string for the D-Bus object path.
+ * - scriptInterface: Name of the D-Bus interface.
+ * - busName: Name of the D-Bus bus.
+ * - io_context: Reference to the Boost.Asio IO context.
+ * - scriptRunner: Reference to the ScriptRunner responsible for script
+ * execution.
+ * - data: Script-specific data.
+ * - objServer: Reference to the sdbusplus object server.
+ * - dbusIface: Shared pointer to the D-Bus interface object.
+ * - timer: Shared pointer to the steady timer used for timeouts.
+ *
+ * Methods:
+ * - ScriptIface(...): Constructor. Sets up the D-Bus interface and registers
+ * methods.
+ * - ~ScriptIface(): Destructor. Cleans up the timer and D-Bus interface.
+ * - cancel(): Cancels the running script via the ScriptRunner.
+ * - startTimeout(): Starts the timeout timer for the script execution.
+ */
+
+struct ScriptIface
+{
+    struct Data
+    {
+        std::string script;
+        std::string id;
+        uint64_t timeout;
+        bool dumpNeeded;
+    };
+    static constexpr auto scriptPath = "/xyz/openbmc_project/acfshell/{}";
+    static constexpr auto scriptInterface = "xyz.openbmc_project.TacfScript";
+    static constexpr std::string_view busName = "xyz.openbmc_project.acfshell";
+    ScriptIface(net::io_context& ioc, ScriptRunner& scriptRunner,
+                const Data& data, sdbusplus::asio::object_server& objServer) :
+        io_context(ioc), scriptRunner(scriptRunner), data(data),
+        objServer(objServer),
+        timer(std::make_shared<boost::asio::steady_timer>(io_context))
+    {
+        std::string path = std::format(scriptPath, data.id);
+        // Create the D-Bus object
+        dbusIface = objServer.add_interface(path.data(), scriptInterface);
+
+        // Register the cancel method
+        dbusIface->register_method("cancel", [this]() { return cancel(); });
+        dbusIface->initialize();
+    }
+    ~ScriptIface()
+    {
+        timer->cancel();
+        objServer.remove_interface(dbusIface);
+    }
+    bool cancel()
+    {
+        bool success = scriptRunner.cancel_script(data.id);
+        if (!success)
+        {
+            LOG_ERROR("Failed to cancel script");
+            return false;
+        }
+        return success;
+    }
+    void startTimeout()
+    {
+        if (data.timeout == 0)
+        {
+            return;
+        }
+        timer->expires_after(std::chrono::seconds(data.timeout));
+        timer->async_wait(
+            [this, timer = timer](const boost::system::error_code& ec) {
+                if (ec)
+                {
+                    return;
+                }
+                LOG_DEBUG("Script {} timed out {}", data.id, data.timeout);
+                cancel();
+            });
+    }
+    net::io_context& io_context;
+    ScriptRunner& scriptRunner;
+    Data data;
+    sdbusplus::asio::object_server& objServer;
+    std::shared_ptr<sdbusplus::asio::dbus_interface> dbusIface;
+    std::shared_ptr<boost::asio::steady_timer> timer;
+};
+} // namespace scrrunner

--- a/acfshell/script_runner.cpp
+++ b/acfshell/script_runner.cpp
@@ -1,0 +1,41 @@
+#include "script_runner.hpp"
+
+#include "acf_shell_iface.hpp"
+#include "sdbus_calls_runner.hpp"
+int main(int argc, char* argv[])
+{
+    using namespace scrrunner;
+    getLogger().setLogLevel(LogLevel::DEBUG);
+    LOG_INFO("Starting script runner");
+    try
+    {
+        net::io_context io_context;
+        auto conn = std::make_shared<sdbusplus::asio::connection>(io_context);
+        ScriptRunner scriptRunner(io_context, conn);
+        AcfShellIface shellIface(io_context, scriptRunner, conn);
+        if (argc > 1)
+        {
+            std::string script = argv[1];
+            std::ifstream file(script);
+            if (!file)
+            {
+                LOG_ERROR("Failed to open script file: {}", script);
+                return 1;
+            }
+            std::string scriptContent((std::istreambuf_iterator<char>(file)),
+                                      std::istreambuf_iterator<char>());
+            net::co_spawn(io_context,
+                          std::bind_front(&AcfShellIface::execute, &shellIface,
+                                          scriptContent),
+                          net::detached);
+        }
+        conn->request_name(AcfShellIface::busName.data());
+        io_context.run();
+    }
+    catch (const std::exception& e)
+    {
+        LOG_ERROR("Exception: {}", e.what());
+        return 1;
+    }
+    return 0;
+}

--- a/acfshell/script_runner.hpp
+++ b/acfshell/script_runner.hpp
@@ -1,0 +1,419 @@
+#pragma once
+#include "logger.hpp"
+#include "sdbus_calls_runner.hpp"
+
+#include <openssl/evp.h>
+
+#include <boost/process.hpp>
+#include <xyz/openbmc_project/Logging/Create/server.hpp>
+#include <xyz/openbmc_project/Logging/Entry/server.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <optional>
+#include <ranges>
+#include <string>
+#include <vector>
+static constexpr auto acfdirectory = "/tmp/acf";
+static constexpr auto dreportexe = "/usr/bin/dreport";
+constexpr auto LOGGING_SVC = "xyz.openbmc_project.Logging";
+constexpr auto LOGGING_PATH = "/xyz/openbmc_project/logging";
+constexpr auto LOGGING_CREATE_INTF = "xyz.openbmc_project.Logging.Create";
+
+namespace bp = boost::process;
+namespace scrrunner
+/**
+ * @brief ScriptRunner is a utility struct for managing the execution of shell
+ * scripts, capturing their output, and optionally triggering dump operations.
+ *
+ * This struct provides asynchronous execution of scripts using Boost.Process
+ * and Boost.Asio, manages script output, and supports cancellation and cleanup
+ * of running scripts. It also supports hashing scripts for identification and
+ * caching purposes.
+ *
+ * Features:
+ * - Asynchronous script execution with output/error capture.
+ * - Optional dump operation after script execution.
+ * - Script file and output file management.
+ * - Script cancellation and cleanup.
+ * - SHA256 hashing of script content for unique identification.
+ *
+ * Usage:
+ * - Use run_script() to start a script asynchronously.
+ * - Use cancel_script() to terminate a running script.
+ * - Script output is written to a file and can be processed as needed.
+ *
+ * Thread Safety:
+ * - Not thread-safe. Intended for use within a single-threaded io_context.
+ *
+ * Dependencies:
+ * - Boost.Process
+ * - Boost.Asio (net)
+ * - OpenSSL EVP API (for hashing)
+ * - C++17 or later (for std::optional, std::filesystem, etc.)
+ *
+ * Example:
+ * @code
+ *   ScriptRunner runner(io_context, dbus_connection);
+ *   runner.run_script("id123", "#!/bin/bash\necho Hello", false, callback);
+ * @endcode
+ */
+{
+struct ScriptRunner
+{
+    std::map<std::string, std::unique_ptr<sdbusplus::bus::match::match>>
+        dumpProgressMatches;
+    using Callback =
+        std::function<void(boost::system::error_code, std::string)>;
+    static std::optional<std::string> makeHash(const std::string& script)
+    {
+        // Create a SHA256 hash of the script string using EVP API
+        unsigned char hash[EVP_MAX_MD_SIZE];
+        unsigned int hash_len;
+        EVP_MD_CTX* mdctx = EVP_MD_CTX_new();
+        if (mdctx == nullptr)
+        {
+            LOG_ERROR("Failed to create EVP_MD_CTX");
+            return std::nullopt;
+        }
+        if (EVP_DigestInit_ex(mdctx, EVP_sha256(), nullptr) != 1 ||
+            EVP_DigestUpdate(mdctx, script.c_str(), script.size()) != 1 ||
+            EVP_DigestFinal_ex(mdctx, hash, &hash_len) != 1)
+        {
+            LOG_ERROR("Failed to compute SHA256 hash");
+            EVP_MD_CTX_free(mdctx);
+            return std::nullopt;
+        }
+        EVP_MD_CTX_free(mdctx);
+
+        // Convert the hash to a hexadecimal string
+        std::string hash_str;
+        for (unsigned int i = 0; i < hash_len; ++i)
+        {
+            char buf[3];
+            snprintf(buf, sizeof(buf), "%02x", hash[i]);
+            hash_str += buf;
+        }
+        // Restrict the hash length to 16 characters
+        constexpr size_t maxHashLen = 16;
+        if (hash_str.length() > maxHashLen)
+        {
+            hash_str.resize(maxHashLen);
+        }
+        return hash_str;
+    }
+    std::string scriptDir(std::string id)
+    {
+        std::string dir = std::format("{}/{}", acfdirectory, id);
+        if (!std::filesystem::exists(dir))
+        {
+            std::filesystem::create_directories(dir);
+        }
+        return dir;
+    }
+    std::string scriptFileName(std::string id)
+    {
+        return std::format("{}/{}.sh", scriptDir(id), id);
+    }
+    std::string scriptOutputFileName(std::string id)
+    {
+        return std::format("{}/{}.out", scriptDir(id), id);
+    }
+    net::awaitable<boost::system::error_code> writeResult(
+        bp::async_pipe& ap, std::ostream& os, std::stop_token token)
+    {
+        std::vector<char> buf(4096);
+        boost::system::error_code ec{};
+        while (!ec && !token.stop_requested())
+        {
+            auto size = co_await net::async_read(
+                ap, net::buffer(buf),
+                net::redirect_error(net::use_awaitable, ec));
+            if (ec && ec != net::error::eof)
+            {
+                LOG_INFO("Error: {}", ec.message());
+                break;
+            }
+            os.write(buf.data(), size);
+        }
+        if (token.stop_requested())
+        {
+            LOG_INFO("Script execution stopped by user");
+            co_return boost::asio::error::operation_aborted;
+        }
+        co_return (ec == net::error::eof ? boost::system::error_code{} : ec);
+    }
+    net::awaitable<boost::system::error_code> writeResult(
+        bp::async_pipe& out, bp::async_pipe& err, std::ostream& ofs,
+        std::stop_token token)
+    {
+        auto ec = co_await writeResult(out, ofs, token);
+        if (ec)
+        {
+            LOG_ERROR("{}", ec.message());
+            co_return ec;
+        }
+        ec = co_await writeResult(err, ofs, token);
+        if (ec)
+        {
+            LOG_ERROR("{}", ec.message());
+            co_return ec;
+        }
+        co_return boost::system::error_code{};
+    }
+    void monitorDumpProgress(const std::string& id, const std::string& dumpId)
+    {
+        std::string matchRule = sdbusplus::bus::match::rules::propertiesChanged(
+            "/xyz/openbmc_project/dump/bmc/entry/" + dumpId,
+            "xyz.openbmc_project.Common.Progress");
+        auto propcallback = [this, id,
+                             dumpId](sdbusplus::message::message& msg) {
+            std::string interfaceName;
+            std::map<std::string, std::variant<std::string>> changedProperties;
+            std::vector<std::string> invalidatedProperties;
+
+            msg.read(interfaceName, changedProperties, invalidatedProperties);
+
+            LOG_INFO("Properties changed on interface: {}", interfaceName);
+
+            changedProperties | std::ranges::views::filter([](const auto& p) {
+                return p.first == "Status";
+            });
+            for (const auto& [prop, value] : changedProperties)
+            {
+                LOG_DEBUG("Dump {} status changed: {}", id,
+                          std::get<std::string>(value));
+                if (std::get<std::string>(value) !=
+                    "xyz.openbmc_project.Common.Progress.OperationStatus.InProgress")
+                {
+                    std::filesystem::remove_all(scriptDir(id));
+                    dumpProgressMatches.erase(dumpId);
+                }
+            }
+        };
+        dumpProgressMatches.emplace(
+            dumpId, std::make_unique<sdbusplus::bus::match::match>(
+                        *conn, matchRule.c_str(), std::move(propcallback)));
+    }
+    net::awaitable<void> startDump(const std::string& id)
+    {
+        using paramtype = std::vector<
+            std::pair<std::string, std::variant<std::string, uint64_t>>>;
+        std::string dumpId;
+        int i = 0;
+        while (i++ < 3)
+        {
+            auto [ec, path] = co_await awaitable_dbus_method_call<
+                sdbusplus::message::object_path>(
+                *conn, "xyz.openbmc_project.Dump.Manager",
+                "/xyz/openbmc_project/dump/bmc",
+                "xyz.openbmc_project.Dump.Create", "CreateDump", paramtype());
+
+            if (!ec)
+            {
+                const std::string dumpPath = path.parent_path().str;
+                dumpId = path.filename();
+                LOG_DEBUG("Dump created for {} at path: {}, id: {}", id,
+                          dumpPath, dumpId);
+                break;
+            }
+            LOG_ERROR("Error creating dump: {}", ec.message());
+            co_await net::steady_timer(io_context, std::chrono::seconds(20))
+                .async_wait(net::use_awaitable);
+        }
+
+        monitorDumpProgress(id, dumpId);
+    }
+
+    net::awaitable<void> createInfoLog(const std::string& info)
+    {
+        std::map<std::string, std::string> additionalData;
+        additionalData.emplace("_PID", std::to_string(getpid()));
+        auto level =
+            sdbusplus::xyz::openbmc_project::Logging::server::convertForMessage(
+                sdbusplus::xyz::openbmc_project::Logging::server::Entry::Level::
+                    Informational);
+        auto [ec, msg] =
+            co_await awaitable_dbus_method_call<sdbusplus::message_t>(
+                *conn, LOGGING_SVC, LOGGING_PATH, LOGGING_CREATE_INTF, "Create",
+                info, level, additionalData);
+        if (ec)
+        {
+            LOG_ERROR("Failed to create error log: {}", ec.message());
+            co_return;
+        }
+    }
+    /**
+     * @brief Executes a script asynchronously using bash and handles its
+     * output.
+     *
+     * This coroutine launches a child process to execute the specified script
+     * file, captures its standard output and error streams, writes the output
+     * to a file, and optionally triggers a dump operation if required. Upon
+     * completion or error, the provided callback is invoked with the result.
+     *
+     * @param filename The path to the script file to execute.
+     * @param hash A unique identifier (hash) for the script execution context.
+     * @param dumpNeeded Indicates whether a dump operation should be performed
+     * after execution.
+     * @param callback A callback function to be called upon completion or
+     * error.
+     *
+     * @return net::awaitable<void> Awaitable coroutine handle.
+     */
+    net::awaitable<void> execute(const std::string& filename,
+                                 const std::string& hash, bool dumpNeeded,
+                                 Callback callback)
+    {
+        try
+        {
+            co_await createInfoLog(
+                std::format("Start executing script: {} with dump needed {}",
+                            filename, dumpNeeded));
+
+            bp::async_pipe ap(io_context);
+            bp::async_pipe ep(io_context);
+
+            boost::system::error_code ec;
+            bp::child c("/usr/bin/bash", filename,
+                        bp::start_dir = scriptDir(hash), bp::std_out > ap,
+                        bp::std_err > ep);
+            if (!c.running())
+            {
+                LOG_ERROR("Failed to start child process");
+                callback(boost::asio::error::operation_aborted, hash);
+                co_return;
+            }
+            auto scritEntry = ScriptEntry{std::ref(c), std::move(callback), {}};
+            auto token = scritEntry.stopSource.get_token();
+            script_cache.emplace(hash, std::move(scritEntry));
+
+            std::ofstream ofs(scriptOutputFileName(hash));
+            co_await writeResult(ap, ep, ofs, token);
+            if (c.exit_code() != 0)
+            {
+                LOG_DEBUG("Script execution failed with exit code: {}",
+                          c.exit_code());
+                ofs << "Script execution failed with exit code: "
+                    << c.exit_code() << std::endl;
+                co_await createInfoLog(
+                    std::format("Script execution failed with exit code: {}",
+                                c.exit_code()));
+            }
+            else
+            {
+                co_await createInfoLog("Script execution Finished");
+            }
+            ofs.close();
+            if (dumpNeeded)
+            {
+                co_await startDump(hash);
+            }
+            else
+            {
+                LOG_DEBUG("Dump not needed for script {}", hash);
+                // Remove the script directory and its contents
+                std::filesystem::remove_all(scriptDir(hash));
+            }
+            invokeCallback(boost::system::error_code{}, hash);
+            remove(hash);
+        }
+        catch (const std::exception& e)
+        {
+            LOG_ERROR("Exception: {}", e.what());
+            callback(boost::asio::error::operation_aborted, hash);
+        }
+    }
+    void invokeCallback(boost::system::error_code ec, const std::string& id)
+    {
+        auto it = script_cache.find(id);
+        if (it == script_cache.end())
+        {
+            return;
+        }
+        it->second.callback(ec, id);
+    }
+    void remove(const std::string& id)
+    {
+        script_cache.erase(id);
+    }
+    bool run_script(const std::string& id, const std::string& script,
+                    bool dumpNeeded, Callback callback)
+    {
+        auto filename = scriptFileName(id);
+        // Write the script to a file
+        std::ofstream script_file(filename);
+        if (!script_file)
+        {
+            LOG_ERROR("Failed to create script file: {}", filename);
+            return false;
+        }
+        script_file << script;
+        script_file.close();
+
+        net::co_spawn(
+            io_context,
+            [this, filename, id, dumpNeeded,
+             callback = std::move(callback)]() mutable -> net::awaitable<void> {
+                co_await execute(filename, id, dumpNeeded, std::move(callback));
+            },
+            net::detached);
+        return true;
+    }
+    /**
+     * @brief Cancels a running script identified by the given ID.
+     *
+     * This function searches for the script in the script cache using the
+     * provided ID. If found, it terminates the associated child process,
+     * invokes the registered callback with a default error code and the
+     * script ID, removes the script from the cache, and returns true. If
+     * the script is not found, it returns false.
+     *
+     * @param id The unique identifier of the script to cancel.
+     * @return true if the script was found and cancelled; false otherwise.
+     */
+    bool cancel_script(const std::string& id)
+    {
+        auto it = script_cache.find(id);
+        if (it == script_cache.end())
+        {
+            return false;
+        }
+        LOG_DEBUG("Cancelling Script {} killig process {} ", id,
+                  it->second.child.get().id());
+        // it->second.child.get().terminate();
+
+        ::kill(it->second.child.get().id(), SIGKILL);
+
+        it->second.callback(boost::system::error_code{}, id);
+        it->second.stopSource.request_stop();
+        remove(id);
+        return true;
+    }
+    ScriptRunner(net::io_context& io_context,
+                 std::shared_ptr<sdbusplus::asio::connection> conn) :
+        io_context(io_context), conn(conn)
+    {}
+    ~ScriptRunner()
+    {
+        while (!script_cache.empty())
+        {
+            auto p = *script_cache.begin();
+            p.second.child.get().terminate();
+            remove(p.first);
+        }
+    }
+    net::io_context& io_context;
+    std::shared_ptr<sdbusplus::asio::connection> conn;
+    struct ScriptEntry
+    {
+        std::reference_wrapper<bp::child> child;
+        std::function<void(boost::system::error_code, std::string)> callback;
+        std::stop_source stopSource;
+    };
+    std::map<std::string, ScriptEntry> script_cache;
+};
+} // namespace scrrunner

--- a/acfshell/sdbus_calls_runner.hpp
+++ b/acfshell/sdbus_calls_runner.hpp
@@ -1,0 +1,332 @@
+/**
+ * @file sdbus_calls_runner.hpp
+ * @brief Provides a set of coroutine-friendly, awaitable wrappers for common
+ * sdbusplus D-Bus operations.
+ *
+ * This header defines a collection of template functions in the `scrrunner`
+ * namespace that simplify making asynchronous D-Bus method calls, property
+ * access, and object mapping queries using sdbusplus with Boost.Asio
+ * integration. All functions return awaitable results, enabling use with C++20
+ * coroutines.
+ *
+ * Main Features:
+ * - Generic awaitable D-Bus method call wrapper.
+ * - Awaitable property get/set helpers.
+ * - ObjectMapper helpers for subtree, object, and association queries.
+ * - Introspection and managed object retrieval.
+ *
+ * @note All functions require a valid `sdbusplus::asio::connection` reference.
+ * @note Error handling is performed via `boost::system::error_code` in the
+ * returned result tuples.
+ *
+ *
+ */
+#pragma once
+#include "logger.hpp"
+#include "make_awaitable_runner.hpp"
+
+#include <sdbusplus/asio/connection.hpp>
+#include <sdbusplus/asio/object_server.hpp>
+#include <sdbusplus/asio/property.hpp>
+#include <sdbusplus/asio/sd_event.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/exception.hpp>
+#include <sdbusplus/server.hpp>
+#include <sdbusplus/timer.hpp>
+
+namespace scrrunner
+{
+template <typename... RetTypes, typename... InputArgs>
+inline auto awaitable_dbus_method_call(
+    sdbusplus::asio::connection& conn, const std::string& service,
+    const std::string& objpath, const std::string& interf,
+    const std::string& method, const InputArgs&... a)
+    -> AwaitableResult<RetTypes...>
+{
+    auto h = make_awaitable_handler<RetTypes...>([&](auto promise) {
+        conn.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           RetTypes... values) mutable {
+                promise.setValues(ec, std::move(values)...);
+            },
+            service, objpath, interf, method, a...);
+    });
+    co_return co_await h();
+}
+
+template <typename Type>
+inline AwaitableResult<Type> getProperty(
+    sdbusplus::asio::connection& conn, const std::string& service,
+    const std::string& objpath, const std::string& interf,
+    const std::string& property)
+{
+    auto [ec, value] =
+        co_await awaitable_dbus_method_call<std::variant<std::monostate, Type>>(
+            conn, service, objpath, "org.freedesktop.DBus.Properties", "Get",
+            interf, property);
+    if (ec)
+    {
+        co_return ReturnTuple<Type>{ec, Type{}};
+    }
+    if (!std::holds_alternative<Type>(value))
+    {
+        LOG_ERROR("Error getting property: Type miss match");
+        co_return ReturnTuple<Type>{ec, Type{}};
+    }
+    co_return ReturnTuple<Type>{ec, std::get<Type>(value)};
+}
+
+template <typename InputArgs>
+inline AwaitableResult<boost::system::error_code> setProperty(
+    sdbusplus::asio::connection& conn, const std::string& service,
+    const std::string& objpath, const std::string& interf,
+    const std::string& property, const InputArgs& value)
+{
+    auto h =
+        make_awaitable_handler<boost::system::error_code>([&](auto promise) {
+            sdbusplus::asio::setProperty(
+                conn, service, objpath, interf, property, value,
+                [promise = std::move(promise)](
+                    boost::system::error_code ec) mutable {
+                    promise.setValues(ec);
+                });
+        });
+    co_return co_await h();
+}
+
+template <typename VariantType>
+inline AwaitableResult<std::vector<std::pair<std::string, VariantType>>>
+    getAllProperties(sdbusplus::asio::connection& bus,
+                     const std::string& service, const std::string& path,
+                     const std::string& interface)
+{
+    using ReturnType = std::vector<std::pair<std::string, VariantType>>;
+    auto h = make_awaitable_handler<ReturnType>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           const ReturnType& data) mutable {
+                promise.setValues(ec, data);
+            },
+            service, path, "org.freedesktop.DBus.Properties", "GetAll",
+            interface);
+    });
+    co_return co_await h();
+}
+
+template <typename SubTreeType>
+inline AwaitableResult<SubTreeType> getSubTree(
+    sdbusplus::asio::connection& bus, const std::string& path, int depth,
+    const std::vector<std::string>& interfaces = {})
+{
+    auto h = make_awaitable_handler<SubTreeType>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           SubTreeType subtree) mutable {
+                promise.setValues(ec, std::move(subtree));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTree", path, depth,
+            interfaces);
+    });
+    co_return co_await h();
+}
+
+template <typename Dict>
+inline AwaitableResult<Dict> getObjects(
+    sdbusplus::asio::connection& bus, const std::string& path,
+    const std::vector<std::string>& interfaces = {})
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetObject", path, interfaces);
+    });
+    co_return co_await h();
+}
+template <typename Dict>
+inline AwaitableResult<Dict> getSubTreePaths(
+    sdbusplus::asio::connection& bus, const std::string& path, int depth,
+    const std::vector<std::string>& interfaces = {})
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetSubTreePaths", path, depth,
+            interfaces);
+    });
+    co_return co_await h();
+}
+template <typename Dict>
+inline AwaitableResult<Dict> getAssociatedSubTree(
+    sdbusplus::asio::connection& bus,
+    const sdbusplus::message::object_path& associatedPath,
+    const sdbusplus::message::object_path& path, int depth,
+    const std::vector<std::string>& interfaces = {})
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetAssociatedSubTree",
+            associatedPath, path, depth, interfaces);
+    });
+    co_return co_await h();
+}
+
+template <typename Dict>
+inline AwaitableResult<Dict> getAssociatedSubTreePaths(
+    sdbusplus::asio::connection& bus,
+    const sdbusplus::message::object_path& associatedPath,
+    const sdbusplus::message::object_path& path, int32_t depth,
+    const std::vector<std::string>& interfaces = {})
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetAssociatedSubTreePaths",
+            associatedPath, path, depth, interfaces);
+    });
+    co_return co_await h();
+}
+
+template <typename Dict>
+inline AwaitableResult<Dict> getAssociatedSubTreeById(
+    sdbusplus::asio::connection& bus, const std::string& id,
+    const std::string& path,
+    std::span<const std::string_view> subtreeInterfaces,
+    std::string_view association,
+    const std::vector<std::string>& endpointInterfaces = {})
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetAssociatedSubTreeById", id,
+            path, subtreeInterfaces, association, endpointInterfaces);
+    });
+    co_return co_await h();
+}
+
+template <typename Dict>
+inline AwaitableResult<Dict> getAssociatedSubTreePathsById(
+    sdbusplus::asio::connection& bus, const std::string& id,
+    const std::string& path,
+    std::span<const std::string_view> subtreeInterfaces,
+    std::string_view association,
+    const std::vector<std::string>& endpointInterfaces)
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetAssociatedSubTreePathsById",
+            id, path, subtreeInterfaces, association, endpointInterfaces);
+    });
+    co_return co_await h();
+}
+
+template <typename Dict>
+inline AwaitableResult<Dict> getDbusObject(
+    sdbusplus::asio::connection& bus, const std::string& path,
+    const std::vector<std::string>& interfaces = {})
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetObject", path, interfaces);
+    });
+    co_return co_await h();
+}
+
+template <typename Dict>
+inline AwaitableResult<Dict> getAssociationEndPoints(
+    sdbusplus::asio::connection& bus, const std::string& path)
+{
+    co_return co_await getProperty<Dict>(
+        bus, "xyz.openbmc_project.ObjectMapper", path,
+        "xyz.openbmc_project.Association", "endpoints");
+}
+
+template <typename Dict>
+inline AwaitableResult<Dict> getManagedObjects(
+    sdbusplus::asio::connection& bus, const std::string& service,
+    const sdbusplus::message::object_path& path)
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            service, path, "org.freedesktop.DBus.ObjectManager",
+            "GetManagedObjects");
+    });
+    co_return co_await h();
+}
+template <typename Dict>
+inline AwaitableResult<Dict> getAncestors(
+    sdbusplus::asio::connection& bus, const std::string& path,
+    const std::vector<std::string>& interfaces = {})
+{
+    auto h = make_awaitable_handler<Dict>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           Dict dict) mutable {
+                promise.setValues(ec, std::move(dict));
+            },
+            "xyz.openbmc_project.ObjectMapper",
+            "/xyz/openbmc_project/object_mapper",
+            "xyz.openbmc_project.ObjectMapper", "GetAncestors", path,
+            interfaces);
+    });
+    co_return co_await h();
+}
+
+inline AwaitableResult<std::string> introspect(
+    sdbusplus::asio::connection& bus, const std::string& service,
+    const sdbusplus::message::object_path& path)
+{
+    auto h = make_awaitable_handler<std::string>([&](auto promise) {
+        bus.async_method_call(
+            [promise = std::move(promise)](boost::system::error_code ec,
+                                           std::string str) mutable {
+                promise.setValues(ec, std::move(str));
+            },
+            service, path, "org.freedesktop.DBus.Introspectable", "Introspect");
+    });
+    co_return co_await h();
+}
+} // namespace scrrunner

--- a/acfshell/service/xyz.openbmc_project.acfshell.conf
+++ b/acfshell/service/xyz.openbmc_project.acfshell.conf
@@ -1,0 +1,10 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-Bus Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+<busconfig>
+  <policy user="root">
+    <allow own="xyz.openbmc_project.acfshell"/>
+    <allow send_destination="xyz.openbmc_project.acfshell"/>
+    <allow send_interface="xyz.openbmc_project.TacfShell"/>
+    <allow send_interface="xyz.openbmc_project.TacfScript"/>
+  </policy>
+</busconfig>

--- a/acfshell/service/xyz.openbmc_project.acfshell.service
+++ b/acfshell/service/xyz.openbmc_project.acfshell.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=BmcShell Script Runner Service
+
+[Service]
+ExecStart=/usr/bin/acfshell
+Restart=always
+Type=dbus
+BusName=xyz.openbmc_project.acfshell
+
+[Install]
+WantedBy=multi-user.target

--- a/meson.build
+++ b/meson.build
@@ -89,6 +89,7 @@ endif
 
 if not get_option('acf-cert-extension').disabled()
     subdir('bmc-acf')
+    subdir('acfshell')
 endif
 
 subdir('dist')


### PR DESCRIPTION
ACFShell is a novel service within the BMC framework, designed to execute scripts embedded within targeted ACF. The BMCShell ACF file contains specific fields that govern the execution of shell scripts within the BMC environment.

```
"shellscript":"xxxxxxxx"
“executionTimeoutInSec”:60
“issueDumpOnCompletion”:”yes|no”
```
shellscript is a script to be executed on the BMC.The shellscript field is base64 encoded.

executionTimeoutInSec is the execution timeout of the shell script in seconds.The BMC will kill the script process when this timeout is reached.

issueDumpOnCompletion upon completion of the script the BMC will optionally initiate a BMC dump which will include the output of the script execution.