### PR TITLE
1120 subject Alternative support

### DIFF
--- a/certs_manager.cpp
+++ b/certs_manager.cpp
@@ -757,12 +757,6 @@ void Manager::generateCSRHelper(
             elog<InternalFailure>();
         }
     }
-
-    else
-    {
-        lg2::error("Empty string is not allowed in SubjectAltNAme");
-        throw InternalFailure();
-    }
     ret = X509_REQ_set_pubkey(x509Req.get(), pKey.get());
     if (ret == 0)
     {


### PR DESCRIPTION
This commit adds supports for including subjectAltName extensions in the CSR. It supports multiple SAN types, such as IP address, DNS, email, and URI.

Tested by:
Generating a CSR with all supported SAN options: Ip address, DNS, Email and URI.
Verifying the CSR output including the subjectAltName extension

Requested Extensions:
X509v3 Subject Alternative Name:
IP Address:192.168.0.1, IP Address:192.168.0.2, IP Address:192.168.0.3

Change-Id: I6a98dd09807122d112672056ade9072b9a0d296f