### PR TITLE
acfshell: changing logs target, fixing cancellation logs

### DIFF
--- a/acfshell/logger.hpp
+++ b/acfshell/logger.hpp
@@ -3,6 +3,7 @@
 
 #include <format>
 #include <iostream>
+#include <source_location>
 #include <string>
 #undef LOG_WARNING
 #undef LOG_ERROR
@@ -15,8 +16,37 @@ enum class LogLevel
     DEBUG,
     INFO,
     WARNING,
-    ERROR
+    ERROR,
+    CRITICAL
 };
+constexpr int toSystemdLevel(LogLevel level)
+{
+    constexpr std::array<std::pair<LogLevel, int>, 5> mapping{
+        {// EMERGENCY 0
+         // ALERT 1
+         {LogLevel::CRITICAL, 2},
+         {LogLevel::ERROR, 3},
+         {LogLevel::WARNING, 4},
+         // NOTICE 5
+         {LogLevel::INFO, 6},
+         // Note, debug here is actually mapped to info level, because OpenBMC
+         // has a MaxLevelSyslog and MaxLevelStore of info, so DEBUG level will
+         // never be stored.
+         {LogLevel::DEBUG, 6}}};
+
+    const auto* it = std::ranges::find_if(
+        mapping, [level](const std::pair<LogLevel, int>& elem) {
+            return elem.first == level;
+        });
+
+    // Unknown log level.  Just assume debug
+    if (it == mapping.end())
+    {
+        return 6;
+    }
+
+    return it->second;
+}
 template <typename OutputStream>
 class Logger
 {
@@ -24,15 +54,25 @@ class Logger
     Logger(LogLevel level, OutputStream& outputStream) :
         currentLogLevel(level), output(outputStream)
     {}
-
-    void log(const char* filename, int lineNumber, LogLevel level,
+    std::string getFileName(const std::source_location& loc) const
+    {
+        std::string_view filename = loc.file_name();
+        filename = filename.substr(filename.rfind('/'));
+        if (!filename.empty())
+        {
+            filename.remove_prefix(1);
+        }
+        return std::string(filename);
+    }
+    void log(const std::source_location& loc, LogLevel level,
              const std::string& message) const
     {
         if (isLogLevelEnabled(level))
         {
-            output << std::format("{}:{} ", filename, lineNumber) << message
+            std::string filename = getFileName(loc);
+            output << std::format("{}:{} ", filename, loc.line()) << message
                    << "\n";
-            output.flush(currentLogLevel);
+            output.flush(toSystemdLevel(currentLogLevel));
         }
     }
 
@@ -58,7 +98,7 @@ struct Lg2Logger
         message += data;
         return *this;
     }
-    void flush(LogLevel level)
+    void flush(int level)
     {
         // Write to systemd journal using sd_journal_send
         // Requires linking with -lsystemd and including <systemd/sd-journal.h>
@@ -79,19 +119,19 @@ inline Logger<Lg2Logger>& getLogger()
 // Macros for clients to use logger
 #define LOG_DEBUG(message, ...)                                                \
     scrrunner::getLogger().log(                                                \
-        __FILE__, __LINE__, scrrunner::LogLevel::DEBUG,                        \
+        std::source_location::current(), scrrunner::LogLevel::DEBUG,           \
         std::format("{} :" message, "Debug", ##__VA_ARGS__))
 #define LOG_INFO(message, ...)                                                 \
     scrrunner::getLogger().log(                                                \
-        __FILE__, __LINE__, scrrunner::LogLevel::INFO,                         \
+        std::source_location::current(), scrrunner::LogLevel::INFO,            \
         std::format("{} :" message, "Info", ##__VA_ARGS__))
 #define LOG_WARNING(message, ...)                                              \
     scrrunner::getLogger().log(                                                \
-        __FILE__, __LINE__, scrrunner::LogLevel::WARNING,                      \
+        std::source_location::current(), scrrunner::LogLevel::WARNING,         \
         std::format("{} :" message, "Warning", ##__VA_ARGS__))
 #define LOG_ERROR(message, ...)                                                \
     scrrunner::getLogger().log(                                                \
-        __FILE__, __LINE__, scrrunner::LogLevel::ERROR,                        \
+        std::source_location::current(), scrrunner::LogLevel::ERROR,           \
         std::format("{} :" message, "Error", ##__VA_ARGS__))
 
 #define CLIENT_LOG_DEBUG(message, ...) LOG_DEBUG(message, ##__VA_ARGS__)

--- a/acfshell/script_iface.hpp
+++ b/acfshell/script_iface.hpp
@@ -79,7 +79,7 @@ struct ScriptIface
         bool success = scriptRunner.cancel_script(data.id);
         if (!success)
         {
-            LOG_ERROR("Failed to cancel script");
+            LOG_DEBUG("Failed to cancel script");
             return false;
         }
         return success;

--- a/acfshell/script_runner.hpp
+++ b/acfshell/script_runner.hpp
@@ -127,6 +127,7 @@ struct ScriptRunner
     {
         std::vector<char> buf(4096);
         boost::system::error_code ec{};
+        std::stop_callback callback(token, [&ap] { ap.close(); });
         while (!ec && !token.stop_requested())
         {
             auto size = co_await net::async_read(
@@ -242,7 +243,7 @@ struct ScriptRunner
                 info, level, additionalData);
         if (ec)
         {
-            LOG_ERROR("Failed to create error log: {}", ec.message());
+            LOG_ERROR("Failed to create pel log: {}", ec.message());
             co_return;
         }
     }
@@ -276,7 +277,6 @@ struct ScriptRunner
 
             bp::async_pipe ap(io_context);
             bp::async_pipe ep(io_context);
-
             boost::system::error_code ec;
             bp::child c("/usr/bin/bash", filename,
                         bp::start_dir = scriptDir(hash), bp::std_out > ap,
@@ -290,18 +290,20 @@ struct ScriptRunner
             auto scritEntry = ScriptEntry{std::ref(c), std::move(callback), {}};
             auto token = scritEntry.stopSource.get_token();
             script_cache.emplace(hash, std::move(scritEntry));
-
             std::ofstream ofs(scriptOutputFileName(hash));
             co_await writeResult(ap, ep, ofs, token);
-            if (c.exit_code() != 0)
+            if (token.stop_requested())
             {
-                LOG_DEBUG("Script execution failed with exit code: {}",
+                LOG_DEBUG("Script execution cancelled , exited with code {}",
                           c.exit_code());
-                ofs << "Script execution failed with exit code: "
-                    << c.exit_code() << std::endl;
+                ofs << std::format(
+                           "Script execution cancelled, exited with code {}",
+                           c.exit_code())
+                    << std::endl;
                 co_await createInfoLog(
-                    std::format("Script execution failed with exit code: {}",
-                                c.exit_code()));
+                    std::format("Script execution cancelled"
+                                " for script: {}, exited with code {}",
+                                hash, c.exit_code()));
             }
             else
             {
@@ -310,11 +312,12 @@ struct ScriptRunner
             ofs.close();
             if (dumpNeeded)
             {
+                LOG_INFO("Dump needed for script {}, starting dump", hash);
                 co_await startDump(hash);
             }
             else
             {
-                LOG_DEBUG("Dump not needed for script {}", hash);
+                LOG_INFO("Dump not needed for script {}", hash);
                 // Remove the script directory and its contents
                 std::filesystem::remove_all(scriptDir(hash));
             }
@@ -377,21 +380,28 @@ struct ScriptRunner
      */
     bool cancel_script(const std::string& id)
     {
-        auto it = script_cache.find(id);
-        if (it == script_cache.end())
+        if (!isRunning(id))
         {
             return false;
         }
+        auto it = script_cache.find(id);
         LOG_DEBUG("Cancelling Script {} killig process {} ", id,
                   it->second.child.get().id());
         // it->second.child.get().terminate();
-
-        ::kill(it->second.child.get().id(), SIGKILL);
-
-        it->second.callback(boost::system::error_code{}, id);
         it->second.stopSource.request_stop();
+        if (::kill(it->second.child.get().id(), SIGKILL) == -1)
+        {
+            LOG_ERROR("Failed to kill process {}: {}",
+                      it->second.child.get().id(), strerror(errno));
+        }
+        it->second.callback(boost::system::error_code{}, id);
         remove(id);
         return true;
+    }
+    bool isRunning(const std::string& id) const
+    {
+        return (script_cache.find(id) != script_cache.end()) &&
+               script_cache.at(id).child.get().running();
     }
     ScriptRunner(net::io_context& io_context,
                  std::shared_ptr<sdbusplus::asio::connection> conn) :


### PR DESCRIPTION
Changing the logger to use sd_journal instead of std::out. Fixes the wrong exit code log creation for normal script finish. Before this fix, the exit code shown for the complete scritp was wrong. This fix will shows cacellation log for cancelled script.Dump will contain reasons for any script errors.