### PR TITLE
PEL Log : Fixing pel not found for cancelled script

### DIFF
--- a/acfshell/script_runner.hpp
+++ b/acfshell/script_runner.hpp
@@ -300,8 +300,8 @@ struct ScriptRunner
                            "Script execution cancelled, exited with code {}",
                            c.exit_code())
                     << std::endl;
-                co_await createInfoLog(
-                    "xyz.openbmc_project.acfshell.ShellCancelled", hash);
+                co_await createInfoLog("xyz.openbmc_project.acfshell.Cancelled",
+                                       hash);
             }
             else
             {


### PR DESCRIPTION
Fixing the typo error in found cancelled pel id