### PR TITLE
Use SHA-256 fingerprint for certificate duplicate detection

### DIFF
--- a/certificate.cpp
+++ b/certificate.cpp
@@ -369,7 +369,6 @@ void Certificate::install(const std::string& certSrcFilePath, bool restore)
 
     // Keep certificate ID
     certId = generateCertId(*cert);
-
     // Parse the certificate file and populate properties
     populateProperties(*cert);
 
@@ -437,11 +436,18 @@ std::string Certificate::getCertId() const
 {
     return certId;
 }
-
 bool Certificate::isSame(const std::string& certPath)
 {
-    internal::X509Ptr cert = loadCert(certPath);
-    return getCertId() == generateCertId(*cert);
+    // Load the new certificate being uploaded
+    internal::X509Ptr newCert = loadCert(certPath);
+    // Load existing certificate from disk
+    internal::X509Ptr existingCert = loadCert(getCertFilePath());
+    // Generate fingerprint of existingCert
+    std::string existingFingerprint =
+        generateCertificateFingerprint(*existingCert);
+    // Generate fingerprint of new certificate
+    std::string newFingerprint = generateCertificateFingerprint(*newCert);
+    return (existingFingerprint == newFingerprint);
 }
 
 void Certificate::storageUpdate()

--- a/x509_utils.cpp
+++ b/x509_utils.cpp
@@ -232,6 +232,24 @@ std::string generateCertId(X509& cert)
 
     return {idBuff};
 }
+std::string generateCertificateFingerprint(X509& cert)
+{
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int mdLen = 0;
+
+    if (!X509_digest(&cert, EVP_sha256(), md, &mdLen))
+    {
+        lg2::error(
+            "Failed to generate certificate fingerprint, ERRCODE:{ERRCODE}",
+            "ERRCODE", ERR_get_error());
+        elog<InternalFailure>();
+    }
+
+    char* hex = OPENSSL_buf2hexstr(md, mdLen);
+    std::string result(hex);
+    OPENSSL_free(hex);
+    return result;
+}
 
 std::unique_ptr<X509, decltype(&::X509_free)> parseCert(const std::string& pem)
 {

--- a/x509_utils.hpp
+++ b/x509_utils.hpp
@@ -58,6 +58,16 @@ void validateCertificateInSSLContext(X509& cert);
  */
 std::string generateCertId(X509& cert);
 
+/**
+ * @brief Generates SHA-256 fingerprint of the certificate.
+ * This is used for reliable duplicate detection that works across
+ * algorithm changes and is FIPS compliant.
+ *
+ * @param[in] cert - Certificate object.
+ *
+ * @return Certificate fingerprint as colon-separated hex string.
+ */
+std::string generateCertificateFingerprint(X509& cert);
 /** @brief Parses PEM string into the X509 structure.
  *  @param[in] pem - PEM encoded X509 certificate buffer.
  *  @return pointer to the X509 structure.


### PR DESCRIPTION
This commit replaces MD5-based certificate ID generation with SHA-256 fingerprint for duplicate detection. The previous implementation used X509_issuer_and_serial_hash() which internally uses MD5. In FIPS mode, MD5 is disabled and this function returns 0, breaking duplicate detection and allowing duplicate certificates to be installed.

The new implementation uses X509_digest() with EVP_sha256() to generate a SHA-256 fingerprint of the entire certificate. This provides reliabl duplicate detection that works in FIPS mode.

Tested by:
    1. Installing new certificate
    2. Attempting to install duplicate - rejected
    3. Code update with pre-existing certificates - duplicate detection works correctly after update.
Signed-off-by: Kokilambal Varadhan <kokilavaradhan@gmail.com>

Change-Id: I019c8ae9debbe7f7538832a5ec8f5bd86c30f376